### PR TITLE
i18n: Complete localization for Django application (pt-BR, en, es)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -90,6 +90,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    'django.middleware.locale.LocaleMiddleware',
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -143,16 +144,25 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "pt-br"
+
+LANGUAGES = [
+    ('pt-br', 'Português (Brasil)'),
+    ('es', 'Español'),
+    ('en', 'English'),
+]
+
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale'),
+]
 
 TIME_ZONE = "UTC"
 
 USE_I18N = True
-
+USE_L10N = True
 USE_TZ = True
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.urls import include, path
 from django.contrib import admin
 from django.conf.urls.static import static
+from django.conf.urls.i18n import i18n_patterns  # ← Adicionar esta linha
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
@@ -21,8 +22,19 @@ urlpatterns = [
     path("api/v1/auth/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/v1/auth/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/v1/mix_citation/", include("config.api_router", namespace="reference")),
+    # URL para trocar idioma
+    path('i18n/', include('django.conf.urls.i18n')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+# URLs com prefixo de idioma
+urlpatterns += i18n_patterns(
+    path("admin/", include(wagtailadmin_urls)),
+    path("documents/", include(wagtaildocs_urls)),
+    path("search/", search_views.search, name="search"),
+    # Wagtail pages - deve ser o último
+    path("", include(wagtail_urls)),
+    # prefix_default_language=False  # Remove /pt-br/ da URL padrão se quiser
+)
 
 if settings.DEBUG:
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.auth import get_user_model
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 User = get_user_model()
 

--- a/core_settings/models.py
+++ b/core_settings/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
 from wagtail.fields import RichTextField

--- a/core_settings/models.py
+++ b/core_settings/models.py
@@ -15,8 +15,8 @@ class CustomSettings(BaseSiteSetting):
     """
 
     class Meta:
-        verbose_name = _("Configuração do site")
-        verbose_name_plural = _("Configuração do site")
+        verbose_name = _("Site configuration")
+        verbose_name_plural = _("Site configuration")
 
     name = models.CharField(max_length=100, null=True, blank=True)
     email = models.EmailField(max_length=100, null=True, blank=True)

--- a/django_celery_beat/button_helper.py
+++ b/django_celery_beat/button_helper.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail_modeladmin.helpers import ButtonHelper
 
 

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -573,7 +573,7 @@ class PeriodicTask(models.Model):
 
     content_panels = [
         HelpPanel(
-            _("Essa é a área de configuração de execução de tarefas assíncronas.")
+            _("This is the configuration area for executing asynchronous tasks.")
         ),
         FieldPanel("name"),
         FieldPanel("regtask"),

--- a/django_celery_beat/views.py
+++ b/django_celery_beat/views.py
@@ -2,7 +2,7 @@ import json
 
 from celery import current_app
 from django.shortcuts import get_object_or_404, redirect
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin import messages
 
 from django_celery_beat import models

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,867 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-03 12:15+0000\n"
+"PO-Revision-Date: 2025-09-03 HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English <en@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: core/home/templates/home/welcome_page.html:6
+msgid "Visit the Wagtail website"
+msgstr "Visit the Wagtail website"
+
+#: core/home/templates/home/welcome_page.html:15
+msgid "View the release notes"
+msgstr "View the release notes"
+
+#: core/home/templates/home/welcome_page.html:27
+msgid "Welcome to your new Wagtail site!"
+msgstr "Welcome to your new Wagtail site!"
+
+#: core/home/templates/home/welcome_page.html:28
+msgid ""
+"Please feel free to <a href=\"https://github.com/wagtail/wagtail/wiki/Slack"
+"\">join our community on Slack</a>, or get started with one of the links "
+"below."
+msgstr ""
+"Please feel free to <a href=\"https://github.com/wagtail/wagtail/wiki/Slack"
+"\">join our community on Slack</a>, or get started with one of the links "
+"below."
+
+#: core/home/templates/home/welcome_page.html:35
+msgid "Wagtail Documentation"
+msgstr "Wagtail Documentation"
+
+#: core/home/templates/home/welcome_page.html:36
+msgid "Topics, references, & how-tos"
+msgstr "Topics, references, & how-tos"
+
+#: core/home/templates/home/welcome_page.html:42
+msgid "Tutorial"
+msgstr "Tutorial"
+
+#: core/home/templates/home/welcome_page.html:43
+msgid "Build your first Wagtail site"
+msgstr "Build your first Wagtail site"
+
+#: core/home/templates/home/welcome_page.html:49
+msgid "Admin Interface"
+msgstr "Admin Interface"
+
+#: core/home/templates/home/welcome_page.html:50
+msgid "Create your superuser first!"
+msgstr "Create your superuser first!"
+
+#: core/models.py:19 tracker/models.py:76
+msgid "Creation date"
+msgstr "Creation date"
+
+#: core/models.py:22
+msgid "Last update date"
+msgstr "Last update date"
+
+#: core/models.py:27
+msgid "Creator"
+msgstr "Creator"
+
+#: core/models.py:37
+msgid "Updater"
+msgstr "Updater"
+
+#: core_settings/models.py:18 core_settings/models.py:19
+msgid "Site configuration"
+msgstr "Site configuration"
+
+#: core_settings/models.py:66
+msgid "Site settings"
+msgstr "Site settings"
+
+#: core_settings/models.py:67
+msgid "Admin settings"
+msgstr "Admin settings"
+
+#: django_celery_beat/admin.py:69 django_celery_beat/forms.py:55
+msgid "Task (registered)"
+msgstr "Task (registered)"
+
+#: django_celery_beat/admin.py:73 django_celery_beat/forms.py:59
+msgid "Task (custom)"
+msgstr "Task (custom)"
+
+#: django_celery_beat/admin.py:90 django_celery_beat/forms.py:75
+msgid "Need name of task"
+msgstr "Need name of task"
+
+#: django_celery_beat/admin.py:96 django_celery_beat/forms.py:81
+#: django_celery_beat/models.py:648
+msgid "Only one can be set, in expires and expire_seconds"
+msgstr "Only one can be set, in expires and expire_seconds"
+
+#: django_celery_beat/admin.py:106 django_celery_beat/forms.py:91
+#, python-format
+msgid "Unable to parse JSON: %s"
+msgstr "Unable to parse JSON: %s"
+
+#: django_celery_beat/admin.py:207 django_celery_beat/wagtail_hooks.py:70
+#, python-brace-format
+msgid "{0} task{1} {2} successfully {3}"
+msgstr "{0} task{1} {2} successfully {3}"
+
+#: django_celery_beat/admin.py:210 django_celery_beat/admin.py:283
+#: django_celery_beat/wagtail_hooks.py:73
+#: django_celery_beat/wagtail_hooks.py:154
+msgid "was,were"
+msgstr "was,were"
+
+#: django_celery_beat/admin.py:220 django_celery_beat/wagtail_hooks.py:83
+msgid "Enable selected tasks"
+msgstr "Enable selected tasks"
+
+#: django_celery_beat/admin.py:227 django_celery_beat/wagtail_hooks.py:90
+msgid "Disable selected tasks"
+msgstr "Disable selected tasks"
+
+#: django_celery_beat/admin.py:242 django_celery_beat/wagtail_hooks.py:105
+msgid "Toggle activity of selected tasks"
+msgstr "Toggle activity of selected tasks"
+
+#: django_celery_beat/admin.py:266 django_celery_beat/wagtail_hooks.py:130
+#, python-brace-format
+msgid "task \"{0}\" not found"
+msgstr "task \"{0}\" not found"
+
+#: django_celery_beat/admin.py:280 django_celery_beat/wagtail_hooks.py:151
+#, python-brace-format
+msgid "{0} task{1} {2} successfully run"
+msgstr "{0} task{1} {2} successfully run"
+
+#: django_celery_beat/admin.py:287 django_celery_beat/wagtail_hooks.py:158
+msgid "Run selected tasks"
+msgstr "Run selected tasks"
+
+#: django_celery_beat/apps.py:13
+msgid "Periodic Tasks"
+msgstr "Periodic Tasks"
+
+#: django_celery_beat/button_helper.py:15
+msgid "Run"
+msgstr "Run"
+
+#: django_celery_beat/choices.py:10
+msgid "Days"
+msgstr "Days"
+
+#: django_celery_beat/choices.py:11
+msgid "Hours"
+msgstr "Hours"
+
+#: django_celery_beat/choices.py:12
+msgid "Minutes"
+msgstr "Minutes"
+
+#: django_celery_beat/choices.py:13
+msgid "Seconds"
+msgstr "Seconds"
+
+#: django_celery_beat/choices.py:14
+msgid "Microseconds"
+msgstr "Microseconds"
+
+#: django_celery_beat/choices.py:18
+msgid "Day"
+msgstr "Day"
+
+#: django_celery_beat/choices.py:19
+msgid "Hour"
+msgstr "Hour"
+
+#: django_celery_beat/choices.py:20
+msgid "Minute"
+msgstr "Minute"
+
+#: django_celery_beat/choices.py:21
+msgid "Second"
+msgstr "Second"
+
+#: django_celery_beat/choices.py:22
+msgid "Microsecond"
+msgstr "Microsecond"
+
+#: django_celery_beat/choices.py:26
+msgid "Astronomical dawn"
+msgstr "Astronomical dawn"
+
+#: django_celery_beat/choices.py:27
+msgid "Civil dawn"
+msgstr "Civil dawn"
+
+#: django_celery_beat/choices.py:28
+msgid "Nautical dawn"
+msgstr "Nautical dawn"
+
+#: django_celery_beat/choices.py:29
+msgid "Astronomical dusk"
+msgstr "Astronomical dusk"
+
+#: django_celery_beat/choices.py:30
+msgid "Civil dusk"
+msgstr "Civil dusk"
+
+#: django_celery_beat/choices.py:31
+msgid "Nautical dusk"
+msgstr "Nautical dusk"
+
+#: django_celery_beat/choices.py:32
+msgid "Solar noon"
+msgstr "Solar noon"
+
+#: django_celery_beat/choices.py:33
+msgid "Sunrise"
+msgstr "Sunrise"
+
+#: django_celery_beat/choices.py:34
+msgid "Sunset"
+msgstr "Sunset"
+
+#: django_celery_beat/models.py:70
+msgid "Solar Event"
+msgstr "Solar Event"
+
+#: django_celery_beat/models.py:71
+msgid "The type of solar event when the job should run"
+msgstr "The type of solar event when the job should run"
+
+#: django_celery_beat/models.py:76
+msgid "Latitude"
+msgstr "Latitude"
+
+#: django_celery_beat/models.py:77
+msgid "Run the task when the event happens at this latitude"
+msgstr "Run the task when the event happens at this latitude"
+
+#: django_celery_beat/models.py:83
+msgid "Longitude"
+msgstr "Longitude"
+
+#: django_celery_beat/models.py:84
+msgid "Run the task when the event happens at this longitude"
+msgstr "Run the task when the event happens at this longitude"
+
+#: django_celery_beat/models.py:91
+msgid "solar event"
+msgstr "solar event"
+
+#: django_celery_beat/models.py:92
+msgid "solar events"
+msgstr "solar events"
+
+#: django_celery_beat/models.py:132
+msgid "Number of Periods"
+msgstr "Number of Periods"
+
+#: django_celery_beat/models.py:134
+msgid "Number of interval periods to wait before running the task again"
+msgstr "Number of interval periods to wait before running the task again"
+
+#: django_celery_beat/models.py:141
+msgid "Interval Period"
+msgstr "Interval Period"
+
+#: django_celery_beat/models.py:142
+msgid "The type of period between task runs (Example: days)"
+msgstr "The type of period between task runs (Example: days)"
+
+#: django_celery_beat/models.py:148
+msgid "interval"
+msgstr "interval"
+
+#: django_celery_beat/models.py:149
+msgid "intervals"
+msgstr "intervals"
+
+#: django_celery_beat/models.py:175
+msgid "every {}"
+msgstr "every {}"
+
+#: django_celery_beat/models.py:180
+msgid "every {} {}"
+msgstr "every {} {}"
+
+#: django_celery_beat/models.py:191
+msgid "Clock Time"
+msgstr "Clock Time"
+
+#: django_celery_beat/models.py:192
+msgid "Run the task at clocked time"
+msgstr "Run the task at clocked time"
+
+#: django_celery_beat/models.py:198 django_celery_beat/models.py:199
+msgid "clocked"
+msgstr "clocked"
+
+#: django_celery_beat/models.py:239
+msgid "Minute(s)"
+msgstr "Minute(s)"
+
+#: django_celery_beat/models.py:240
+msgid "Cron Minutes to Run. Use \"*\" for \"all\". (Example: \"0,30\")"
+msgstr "Cron Minutes to Run. Use \"*\" for \"all\". (Example: \"0,30\")"
+
+#: django_celery_beat/models.py:246
+msgid "Hour(s)"
+msgstr "Hour(s)"
+
+#: django_celery_beat/models.py:247
+msgid "Cron Hours to Run. Use \"*\" for \"all\". (Example: \"8,20\")"
+msgstr "Cron Hours to Run. Use \"*\" for \"all\". (Example: \"8,20\")"
+
+#: django_celery_beat/models.py:253
+msgid "Day(s) Of The Week"
+msgstr "Day(s) Of The Week"
+
+#: django_celery_beat/models.py:255
+msgid "Cron Days Of The Week to Run. Use \"*\" for \"all\". (Example: \"0,5\")"
+msgstr ""
+"Cron Days Of The Week to Run. Use \"*\" for \"all\". (Example: \"0,5\")"
+
+#: django_celery_beat/models.py:262
+msgid "Day(s) Of The Month"
+msgstr "Day(s) Of The Month"
+
+#: django_celery_beat/models.py:264
+msgid ""
+"Cron Days Of The Month to Run. Use \"*\" for \"all\". (Example: \"1,15\")"
+msgstr ""
+"Cron Days Of The Month to Run. Use \"*\" for \"all\". (Example: \"1,15\")"
+
+#: django_celery_beat/models.py:271
+msgid "Month(s) Of The Year"
+msgstr "Month(s) Of The Year"
+
+#: django_celery_beat/models.py:273
+msgid ""
+"Cron Months Of The Year to Run. Use \"*\" for \"all\". (Example: \"0,6\")"
+msgstr ""
+"Cron Months Of The Year to Run. Use \"*\" for \"all\". (Example: \"0,6\")"
+
+#: django_celery_beat/models.py:280
+msgid "Cron Timezone"
+msgstr "Cron Timezone"
+
+#: django_celery_beat/models.py:281
+msgid "Timezone to Run the Cron Schedule on. Default is UTC."
+msgstr "Timezone to Run the Cron Schedule on. Default is UTC."
+
+#: django_celery_beat/models.py:287
+msgid "crontab"
+msgstr "crontab"
+
+#: django_celery_beat/models.py:288
+msgid "crontabs"
+msgstr "crontabs"
+
+#: django_celery_beat/models.py:385
+msgid "Name"
+msgstr "Name"
+
+#: django_celery_beat/models.py:386
+msgid "Short Description For This Task"
+msgstr "Short Description For This Task"
+
+#: django_celery_beat/models.py:392
+msgid ""
+"The Name of the Celery Task that Should be Run.  (Example: \"proj.tasks."
+"import_contacts\")"
+msgstr ""
+"The Name of the Celery Task that Should be Run.  (Example: \"proj.tasks."
+"import_contacts\")"
+
+#: django_celery_beat/models.py:404
+msgid "Interval Schedule"
+msgstr "Interval Schedule"
+
+#: django_celery_beat/models.py:406
+msgid ""
+"Interval Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Interval Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+
+#: django_celery_beat/models.py:415
+msgid "Crontab Schedule"
+msgstr "Crontab Schedule"
+
+#: django_celery_beat/models.py:417
+msgid ""
+"Crontab Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Crontab Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+
+#: django_celery_beat/models.py:426
+msgid "Solar Schedule"
+msgstr "Solar Schedule"
+
+#: django_celery_beat/models.py:428
+msgid ""
+"Solar Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Solar Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+
+#: django_celery_beat/models.py:437
+msgid "Clocked Schedule"
+msgstr "Clocked Schedule"
+
+#: django_celery_beat/models.py:439
+msgid ""
+"Clocked Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Clocked Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+
+#: django_celery_beat/models.py:447
+msgid "Positional Arguments"
+msgstr "Positional Arguments"
+
+#: django_celery_beat/models.py:448
+msgid "JSON encoded positional arguments (Example: [\"arg1\", \"arg2\"])"
+msgstr "JSON encoded positional arguments (Example: [\"arg1\", \"arg2\"])"
+
+#: django_celery_beat/models.py:453
+msgid "Keyword Arguments"
+msgstr "Keyword Arguments"
+
+#: django_celery_beat/models.py:455
+msgid "JSON encoded keyword arguments (Example: {\"argument\": \"value\"})"
+msgstr "JSON encoded keyword arguments (Example: {\"argument\": \"value\"})"
+
+#: django_celery_beat/models.py:464
+msgid "Queue Override"
+msgstr "Queue Override"
+
+#: django_celery_beat/models.py:466
+msgid "Queue defined in CELERY_TASK_QUEUES. Leave None for default queuing."
+msgstr "Queue defined in CELERY_TASK_QUEUES. Leave None for default queuing."
+
+#: django_celery_beat/models.py:478
+msgid "Exchange"
+msgstr "Exchange"
+
+#: django_celery_beat/models.py:479
+msgid "Override Exchange for low-level AMQP routing"
+msgstr "Override Exchange for low-level AMQP routing"
+
+#: django_celery_beat/models.py:486
+msgid "Routing Key"
+msgstr "Routing Key"
+
+#: django_celery_beat/models.py:487
+msgid "Override Routing Key for low-level AMQP routing"
+msgstr "Override Routing Key for low-level AMQP routing"
+
+#: django_celery_beat/models.py:492
+msgid "AMQP Message Headers"
+msgstr "AMQP Message Headers"
+
+#: django_celery_beat/models.py:493
+msgid "JSON encoded message headers for the AMQP message."
+msgstr "JSON encoded message headers for the AMQP message."
+
+#: django_celery_beat/models.py:501
+msgid "Priority"
+msgstr "Priority"
+
+#: django_celery_beat/models.py:503
+msgid ""
+"Priority Number between 0 and 255. Supported by: RabbitMQ, Redis (priority "
+"reversed, 0 is highest)."
+msgstr ""
+"Priority Number between 0 and 255. Supported by: RabbitMQ, Redis (priority "
+"reversed, 0 is highest)."
+
+#: django_celery_beat/models.py:510
+msgid "Expires Datetime"
+msgstr "Expires Datetime"
+
+#: django_celery_beat/models.py:512
+msgid ""
+"Datetime after which the schedule will no longer trigger the task to run"
+msgstr ""
+"Datetime after which the schedule will no longer trigger the task to run"
+
+#: django_celery_beat/models.py:519
+msgid "Expires timedelta with seconds"
+msgstr "Expires timedelta with seconds"
+
+#: django_celery_beat/models.py:521
+msgid ""
+"Timedelta with seconds which the schedule will no longer trigger the task to "
+"run"
+msgstr ""
+"Timedelta with seconds which the schedule will no longer trigger the task to "
+"run"
+
+#: django_celery_beat/models.py:527
+msgid "One-off Task"
+msgstr "One-off Task"
+
+#: django_celery_beat/models.py:528
+msgid "If True, the schedule will only run the task a single time"
+msgstr "If True, the schedule will only run the task a single time"
+
+#: django_celery_beat/models.py:533
+msgid "Start Datetime"
+msgstr "Start Datetime"
+
+#: django_celery_beat/models.py:535
+msgid "Datetime when the schedule should begin triggering the task to run"
+msgstr "Datetime when the schedule should begin triggering the task to run"
+
+#: django_celery_beat/models.py:540
+msgid "Enabled"
+msgstr "Enabled"
+
+#: django_celery_beat/models.py:541
+msgid "Set to False to disable the schedule"
+msgstr "Set to False to disable the schedule"
+
+#: django_celery_beat/models.py:549
+msgid "Last Run Datetime"
+msgstr "Last Run Datetime"
+
+#: django_celery_beat/models.py:551
+msgid ""
+"Datetime that the schedule last triggered the task to run. Reset to None if "
+"enabled is set to False."
+msgstr ""
+"Datetime that the schedule last triggered the task to run. Reset to None if "
+"enabled is set to False."
+
+#: django_celery_beat/models.py:558
+msgid "Total Run Count"
+msgstr "Total Run Count"
+
+#: django_celery_beat/models.py:560
+msgid "Running count of how many times the schedule has triggered the task"
+msgstr "Running count of how many times the schedule has triggered the task"
+
+#: django_celery_beat/models.py:565
+msgid "Last Modified"
+msgstr "Last Modified"
+
+#: django_celery_beat/models.py:566
+msgid "Datetime that this PeriodicTask was last modified"
+msgstr "Datetime that this PeriodicTask was last modified"
+
+#: django_celery_beat/models.py:570
+msgid "Description"
+msgstr "Description"
+
+#: django_celery_beat/models.py:571
+msgid "Detailed description about the details of this Periodic Task"
+msgstr "Detailed description about the details of this Periodic Task"
+
+#: django_celery_beat/models.py:576
+msgid "This is the configuration area for executing asynchronous tasks."
+msgstr "This is the configuration area for executing asynchronous tasks."
+
+#: django_celery_beat/models.py:597
+msgid "Content"
+msgstr "Content"
+
+#: django_celery_beat/models.py:598
+msgid "Scheduler"
+msgstr "Scheduler"
+
+#: django_celery_beat/models.py:608
+msgid "periodic task"
+msgstr "periodic task"
+
+#: django_celery_beat/models.py:609
+msgid "periodic tasks"
+msgstr "periodic tasks"
+
+#: django_celery_beat/templates/admin/djcelery/change_list.html:6
+msgid "Home"
+msgstr "Home"
+
+#: django_celery_beat/views.py:34
+#, python-brace-format
+msgid "Task {0} was successfully run"
+msgstr "Task {0} was successfully run"
+
+#: django_celery_beat/wagtail_hooks.py:193
+msgid "Tasks"
+msgstr "Tasks"
+
+#: reference/models.py:34
+msgid "Marked"
+msgstr "Marked"
+
+#: reference/models.py:35
+msgid "Marked XML"
+msgstr "Marked XML"
+
+#: reference/wagtail_hooks.py:45
+msgid "Reference"
+msgstr "Reference"
+
+#: tracker/choices.py:9
+msgid "error"
+msgstr "error"
+
+#: tracker/choices.py:10
+msgid "warning"
+msgstr "warning"
+
+#: tracker/choices.py:11
+msgid "info"
+msgstr "info"
+
+#: tracker/choices.py:12
+msgid "exception"
+msgstr "exception"
+
+#: tracker/choices.py:24
+msgid "To reprocess"
+msgstr "To reprocess"
+
+#: tracker/choices.py:25
+msgid "To do"
+msgstr "To do"
+
+#: tracker/choices.py:26
+msgid "Done"
+msgstr "Done"
+
+#: tracker/choices.py:27
+msgid "Doing"
+msgstr "Doing"
+
+#: tracker/choices.py:28
+msgid "Pending"
+msgstr "Pending"
+
+#: tracker/choices.py:29
+msgid "ignored"
+msgstr "ignored"
+
+#: tracker/choices.py:41
+msgid "XML Parsing Error"
+msgstr "XML Parsing Error"
+
+#: tracker/choices.py:42
+msgid "XML Validation Error"
+msgstr "XML Validation Error"
+
+#: tracker/choices.py:43
+msgid "XML Conversion to DOCX Error"
+msgstr "XML Conversion to DOCX Error"
+
+#: tracker/choices.py:44
+msgid "XML Conversion to HTML Error"
+msgstr "XML Conversion to HTML Error"
+
+#: tracker/choices.py:45
+msgid "XML Conversion to PDF Error"
+msgstr "XML Conversion to PDF Error"
+
+#: tracker/choices.py:46
+msgid "XML Conversion to TEX Error"
+msgstr "XML Conversion to TEX Error"
+
+#: tracker/choices.py:47
+msgid "Unknown Error"
+msgstr "Unknown Error"
+
+#: tracker/models.py:28
+msgid "Error Type"
+msgstr "Error Type"
+
+#: tracker/models.py:35
+msgid "Data"
+msgstr "Data"
+
+#: tracker/models.py:39
+msgid "Message"
+msgstr "Message"
+
+#: tracker/models.py:44
+msgid "Handled"
+msgstr "Handled"
+
+#: tracker/models.py:70
+msgid "XML Document Event"
+msgstr "XML Document Event"
+
+#: tracker/models.py:71 tracker/wagtail_hooks.py:16
+msgid "XML Document Events"
+msgstr "XML Document Events"
+
+#: tracker/models.py:77
+msgid "Exception Type"
+msgstr "Exception Type"
+
+#: tracker/models.py:78
+msgid "Exception Msg"
+msgstr "Exception Msg"
+
+#: tracker/models.py:82
+msgid "Item"
+msgstr "Item"
+
+#: tracker/models.py:88 xml_manager/wagtail_hooks.py:69
+msgid "Action"
+msgstr "Action"
+
+#: tracker/models.py:101
+msgid "General Event"
+msgstr "General Event"
+
+#: tracker/models.py:102 tracker/wagtail_hooks.py:47
+msgid "General Events"
+msgstr "General Events"
+
+#: tracker/wagtail_hooks.py:81
+msgid "Unexpected Events"
+msgstr "Unexpected Events"
+
+#: users/admin.py:13
+msgid "Personal info"
+msgstr "Personal info"
+
+#: users/admin.py:15
+msgid "Permissions"
+msgstr "Permissions"
+
+#: users/admin.py:26
+msgid "Important dates"
+msgstr "Important dates"
+
+#: users/forms.py:11
+msgid "This username has already been taken."
+msgstr "This username has already been taken."
+
+#: users/models.py:15
+msgid "Name of User"
+msgstr "Name of User"
+
+#: xml_manager/models.py:9
+msgid "XML File"
+msgstr "XML File"
+
+#: xml_manager/models.py:10
+msgid "Upload an XML file for processing."
+msgstr "Upload an XML file for processing."
+
+#: xml_manager/models.py:16
+msgid "Validation File"
+msgstr "Validation File"
+
+#: xml_manager/models.py:22
+msgid "Exceptions File"
+msgstr "Exceptions File"
+
+#: xml_manager/models.py:26 xml_manager/models.py:61 xml_manager/models.py:93
+msgid "Uploaded At"
+msgstr "Uploaded At"
+
+#: xml_manager/models.py:27
+msgid "The date and time when the file was uploaded."
+msgstr "The date and time when the file was uploaded."
+
+#: xml_manager/models.py:38 xml_manager/models.py:43 xml_manager/models.py:82
+#: xml_manager/wagtail_hooks.py:56 xml_manager/wagtail_hooks.py:60
+msgid "XML Document"
+msgstr "XML Document"
+
+#: xml_manager/models.py:39 xml_manager/wagtail_hooks.py:57
+msgid "XML Documents"
+msgstr "XML Documents"
+
+#: xml_manager/models.py:46
+msgid "PDF File"
+msgstr "PDF File"
+
+#: xml_manager/models.py:50
+msgid "DOCX File"
+msgstr "DOCX File"
+
+#: xml_manager/models.py:53
+msgid "Intermediate DOCX file generated during PDF creation"
+msgstr "Intermediate DOCX file generated during PDF creation"
+
+#: xml_manager/models.py:58 xml_manager/models.py:90
+msgid "Language"
+msgstr "Language"
+
+#: xml_manager/models.py:59 xml_manager/models.py:91
+msgid "Language code or name"
+msgstr "Language code or name"
+
+#: xml_manager/models.py:67 xml_manager/wagtail_hooks.py:77
+#: xml_manager/wagtail_hooks.py:81
+msgid "XML Document PDF"
+msgstr "XML Document PDF"
+
+#: xml_manager/models.py:68 xml_manager/wagtail_hooks.py:78
+msgid "XML Document PDFs"
+msgstr "XML Document PDFs"
+
+#: xml_manager/models.py:85
+msgid "HTML File"
+msgstr "HTML File"
+
+#: xml_manager/models.py:99 xml_manager/wagtail_hooks.py:98
+#: xml_manager/wagtail_hooks.py:102
+msgid "XML Document HTML"
+msgstr "XML Document HTML"
+
+#: xml_manager/models.py:100 xml_manager/wagtail_hooks.py:99
+msgid "XML Document HTMLs"
+msgstr "XML Document HTMLs"
+
+#: xml_manager/wagtail_hooks.py:66
+msgid "Validation file"
+msgstr "Validation file"
+
+#: xml_manager/wagtail_hooks.py:67
+msgid "Exceptions file"
+msgstr "Exceptions file"
+
+#: xml_manager/wagtail_hooks.py:118
+msgid "XML Manager"
+msgstr "XML Manager"
+
+#, fuzzy
+#~| msgid "Action"
+#~ msgid "Actions"
+#~ msgstr "Action"
+
+#~ msgid "Ações"
+#~ msgstr "Actions"
+
+#, fuzzy
+#~| msgid "Essa é a área de configuração de execuçãoo de tarefas assíncronas."
+#~ msgid "Essa é a área de configuração de execução de tarefas assíncronas."
+#~ msgstr "This is the configuration area for executing asynchronous tasks."
+
+#~ msgid "Configuração do site"
+#~ msgstr "Site configuration"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-03 12:15+0000\n"
+"POT-Creation-Date: 2025-09-04 14:18+0000\n"
 "PO-Revision-Date: 2025-09-03 HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English <en@li.org>\n"
@@ -611,13 +611,33 @@ msgstr "Task {0} was successfully run"
 msgid "Tasks"
 msgstr "Tasks"
 
-#: reference/models.py:34
+#: reference/models.py:15
+msgid "Mixed Citation"
+msgstr "Mixed Citation"
+
+#: reference/models.py:30
+#, fuzzy
+#| msgid "Reference"
+msgid "Referência"
+msgstr "Reference"
+
+#: reference/models.py:31
+#, fuzzy
+#| msgid "Reference"
+msgid "Referências"
+msgstr "Reference"
+
+#: reference/models.py:38
 msgid "Marked"
 msgstr "Marked"
 
-#: reference/models.py:35
+#: reference/models.py:39
 msgid "Marked XML"
 msgstr "Marked XML"
+
+#: reference/models.py:48
+msgid "Rating from 1 to 10"
+msgstr "Rating from 1 to 10"
 
 #: reference/wagtail_hooks.py:45
 msgid "Reference"
@@ -849,6 +869,19 @@ msgstr "Exceptions file"
 #: xml_manager/wagtail_hooks.py:118
 msgid "XML Manager"
 msgstr "XML Manager"
+
+#, fuzzy
+#~| msgid "Marked"
+#~ msgid "marked"
+#~ msgstr "Marked"
+
+#, fuzzy
+#~| msgid "Marked"
+#~ msgid "marked_xml"
+#~ msgstr "Marked"
+
+#~ msgid "score"
+#~ msgstr "pontuação"
 
 #, fuzzy
 #~| msgid "Action"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-03 12:48+0000\n"
+"POT-Creation-Date: 2025-09-04 14:18+0000\n"
 "PO-Revision-Date: 2025-09-03 HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -625,13 +625,33 @@ msgstr "La tarea {0} fue ejecutada exitosamente"
 msgid "Tasks"
 msgstr "Tareas"
 
-#: reference/models.py:34
+#: reference/models.py:15
+msgid "Mixed Citation"
+msgstr "Cita mixta"
+
+#: reference/models.py:30
+#, fuzzy
+#| msgid "Reference"
+msgid "Referência"
+msgstr "Referencia"
+
+#: reference/models.py:31
+#, fuzzy
+#| msgid "Reference"
+msgid "Referências"
+msgstr "Referencia"
+
+#: reference/models.py:38
 msgid "Marked"
 msgstr "Marcado"
 
-#: reference/models.py:35
+#: reference/models.py:39
 msgid "Marked XML"
 msgstr "XML Marcado"
+
+#: reference/models.py:48
+msgid "Rating from 1 to 10"
+msgstr "Calificación del 1 al 10"
 
 #: reference/wagtail_hooks.py:45
 msgid "Reference"
@@ -863,6 +883,19 @@ msgstr "Archivo de excepciones"
 #: xml_manager/wagtail_hooks.py:118
 msgid "XML Manager"
 msgstr "Gestor XML"
+
+#, fuzzy
+#~| msgid "Marked"
+#~ msgid "marked"
+#~ msgstr "Marcado"
+
+#, fuzzy
+#~| msgid "Marked"
+#~ msgid "marked_xml"
+#~ msgstr "Marcado"
+
+#~ msgid "score"
+#~ msgstr "puntaje"
 
 #~ msgid "AÃ§Ãµes"
 #~ msgstr "Acciones"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,868 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-03 12:48+0000\n"
+"PO-Revision-Date: 2025-09-03 HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Spanish <es@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+
+#: core/home/templates/home/welcome_page.html:6
+msgid "Visit the Wagtail website"
+msgstr "Visita el sitio web de Wagtail"
+
+#: core/home/templates/home/welcome_page.html:15
+msgid "View the release notes"
+msgstr "Ver las notas de lanzamiento"
+
+#: core/home/templates/home/welcome_page.html:27
+msgid "Welcome to your new Wagtail site!"
+msgstr "¡Bienvenido a tu nuevo sitio Wagtail!"
+
+#: core/home/templates/home/welcome_page.html:28
+msgid ""
+"Please feel free to <a href=\"https://github.com/wagtail/wagtail/wiki/Slack"
+"\">join our community on Slack</a>, or get started with one of the links "
+"below."
+msgstr ""
+"Siéntete libre de <a href=\"https://github.com/wagtail/wagtail/wiki/Slack"
+"\">unirte a nuestra comunidad en Slack</a>, o comenzar con uno de los "
+"enlaces a continuación."
+
+#: core/home/templates/home/welcome_page.html:35
+msgid "Wagtail Documentation"
+msgstr "Documentación de Wagtail"
+
+#: core/home/templates/home/welcome_page.html:36
+msgid "Topics, references, & how-tos"
+msgstr "Temas, referencias y guías prácticas"
+
+#: core/home/templates/home/welcome_page.html:42
+msgid "Tutorial"
+msgstr "Tutorial"
+
+#: core/home/templates/home/welcome_page.html:43
+msgid "Build your first Wagtail site"
+msgstr "Construye tu primer sitio Wagtail"
+
+#: core/home/templates/home/welcome_page.html:49
+msgid "Admin Interface"
+msgstr "Interfaz de Administración"
+
+#: core/home/templates/home/welcome_page.html:50
+msgid "Create your superuser first!"
+msgstr "¡Crea tu superusuario primero!"
+
+#: core/models.py:19 tracker/models.py:76
+msgid "Creation date"
+msgstr "Fecha de creación"
+
+#: core/models.py:22
+msgid "Last update date"
+msgstr "Fecha de última actualización"
+
+#: core/models.py:27
+msgid "Creator"
+msgstr "Creador"
+
+#: core/models.py:37
+msgid "Updater"
+msgstr "Actualizador"
+
+#: core_settings/models.py:18 core_settings/models.py:19
+msgid "Site configuration"
+msgstr "Configuración del sitio"
+
+#: core_settings/models.py:66
+msgid "Site settings"
+msgstr "Configuración del sitio"
+
+#: core_settings/models.py:67
+msgid "Admin settings"
+msgstr "Configuración de administración"
+
+#: django_celery_beat/admin.py:69 django_celery_beat/forms.py:55
+msgid "Task (registered)"
+msgstr "Tarea (registrada)"
+
+#: django_celery_beat/admin.py:73 django_celery_beat/forms.py:59
+msgid "Task (custom)"
+msgstr "Tarea (personalizada)"
+
+#: django_celery_beat/admin.py:90 django_celery_beat/forms.py:75
+msgid "Need name of task"
+msgstr "Se necesita el nombre de la tarea"
+
+#: django_celery_beat/admin.py:96 django_celery_beat/forms.py:81
+#: django_celery_beat/models.py:648
+msgid "Only one can be set, in expires and expire_seconds"
+msgstr "Solo uno puede establecerse, entre expires y expire_seconds"
+
+#: django_celery_beat/admin.py:106 django_celery_beat/forms.py:91
+#, python-format
+msgid "Unable to parse JSON: %s"
+msgstr "No se puede analizar JSON: %s"
+
+#: django_celery_beat/admin.py:207 django_celery_beat/wagtail_hooks.py:70
+#, python-brace-format
+msgid "{0} task{1} {2} successfully {3}"
+msgstr "{0} tarea{1} {2} exitosamente {3}"
+
+#: django_celery_beat/admin.py:210 django_celery_beat/admin.py:283
+#: django_celery_beat/wagtail_hooks.py:73
+#: django_celery_beat/wagtail_hooks.py:154
+msgid "was,were"
+msgstr "fue,fueron"
+
+#: django_celery_beat/admin.py:220 django_celery_beat/wagtail_hooks.py:83
+msgid "Enable selected tasks"
+msgstr "Habilitar tareas seleccionadas"
+
+#: django_celery_beat/admin.py:227 django_celery_beat/wagtail_hooks.py:90
+msgid "Disable selected tasks"
+msgstr "Deshabilitar tareas seleccionadas"
+
+#: django_celery_beat/admin.py:242 django_celery_beat/wagtail_hooks.py:105
+msgid "Toggle activity of selected tasks"
+msgstr "Alternar actividad de las tareas seleccionadas"
+
+#: django_celery_beat/admin.py:266 django_celery_beat/wagtail_hooks.py:130
+#, python-brace-format
+msgid "task \"{0}\" not found"
+msgstr "tarea \"{0}\" no encontrada"
+
+#: django_celery_beat/admin.py:280 django_celery_beat/wagtail_hooks.py:151
+#, python-brace-format
+msgid "{0} task{1} {2} successfully run"
+msgstr "{0} tarea{1} {2} ejecutada{1} exitosamente"
+
+#: django_celery_beat/admin.py:287 django_celery_beat/wagtail_hooks.py:158
+msgid "Run selected tasks"
+msgstr "Ejecutar tareas seleccionadas"
+
+#: django_celery_beat/apps.py:13
+msgid "Periodic Tasks"
+msgstr "Tareas Periódicas"
+
+#: django_celery_beat/button_helper.py:15
+msgid "Run"
+msgstr "Ejecutar"
+
+#: django_celery_beat/choices.py:10
+msgid "Days"
+msgstr "Días"
+
+#: django_celery_beat/choices.py:11
+msgid "Hours"
+msgstr "Horas"
+
+#: django_celery_beat/choices.py:12
+msgid "Minutes"
+msgstr "Minutos"
+
+#: django_celery_beat/choices.py:13
+msgid "Seconds"
+msgstr "Segundos"
+
+#: django_celery_beat/choices.py:14
+msgid "Microseconds"
+msgstr "Microsegundos"
+
+#: django_celery_beat/choices.py:18
+msgid "Day"
+msgstr "Día"
+
+#: django_celery_beat/choices.py:19
+msgid "Hour"
+msgstr "Hora"
+
+#: django_celery_beat/choices.py:20
+msgid "Minute"
+msgstr "Minuto"
+
+#: django_celery_beat/choices.py:21
+msgid "Second"
+msgstr "Segundo"
+
+#: django_celery_beat/choices.py:22
+msgid "Microsecond"
+msgstr "Microsegundo"
+
+#: django_celery_beat/choices.py:26
+msgid "Astronomical dawn"
+msgstr "Amanecer astronómico"
+
+#: django_celery_beat/choices.py:27
+msgid "Civil dawn"
+msgstr "Amanecer civil"
+
+#: django_celery_beat/choices.py:28
+msgid "Nautical dawn"
+msgstr "Amanecer náutico"
+
+#: django_celery_beat/choices.py:29
+msgid "Astronomical dusk"
+msgstr "Anochecer astronómico"
+
+#: django_celery_beat/choices.py:30
+msgid "Civil dusk"
+msgstr "Anochecer civil"
+
+#: django_celery_beat/choices.py:31
+msgid "Nautical dusk"
+msgstr "Anochecer náutico"
+
+#: django_celery_beat/choices.py:32
+msgid "Solar noon"
+msgstr "Mediodía solar"
+
+#: django_celery_beat/choices.py:33
+msgid "Sunrise"
+msgstr "Amanecer"
+
+#: django_celery_beat/choices.py:34
+msgid "Sunset"
+msgstr "Atardecer"
+
+#: django_celery_beat/models.py:70
+msgid "Solar Event"
+msgstr "Evento Solar"
+
+#: django_celery_beat/models.py:71
+msgid "The type of solar event when the job should run"
+msgstr "El tipo de evento solar cuando la tarea debe ejecutarse"
+
+#: django_celery_beat/models.py:76
+msgid "Latitude"
+msgstr "Latitud"
+
+#: django_celery_beat/models.py:77
+msgid "Run the task when the event happens at this latitude"
+msgstr "Ejecutar la tarea cuando el evento ocurra en esta latitud"
+
+#: django_celery_beat/models.py:83
+msgid "Longitude"
+msgstr "Longitud"
+
+#: django_celery_beat/models.py:84
+msgid "Run the task when the event happens at this longitude"
+msgstr "Ejecutar la tarea cuando el evento ocurra en esta longitud"
+
+#: django_celery_beat/models.py:91
+msgid "solar event"
+msgstr "evento solar"
+
+#: django_celery_beat/models.py:92
+msgid "solar events"
+msgstr "eventos solares"
+
+#: django_celery_beat/models.py:132
+msgid "Number of Periods"
+msgstr "Número de Períodos"
+
+#: django_celery_beat/models.py:134
+msgid "Number of interval periods to wait before running the task again"
+msgstr ""
+"Número de períodos de intervalo a esperar antes de ejecutar la tarea "
+"nuevamente"
+
+#: django_celery_beat/models.py:141
+msgid "Interval Period"
+msgstr "Período de Intervalo"
+
+#: django_celery_beat/models.py:142
+msgid "The type of period between task runs (Example: days)"
+msgstr "El tipo de período entre ejecuciones de la tarea (Ejemplo: días)"
+
+#: django_celery_beat/models.py:148
+msgid "interval"
+msgstr "intervalo"
+
+#: django_celery_beat/models.py:149
+msgid "intervals"
+msgstr "intervalos"
+
+#: django_celery_beat/models.py:175
+msgid "every {}"
+msgstr "cada {}"
+
+#: django_celery_beat/models.py:180
+msgid "every {} {}"
+msgstr "cada {} {}"
+
+#: django_celery_beat/models.py:191
+msgid "Clock Time"
+msgstr "Hora del Reloj"
+
+#: django_celery_beat/models.py:192
+msgid "Run the task at clocked time"
+msgstr "Ejecutar la tarea a la hora programada"
+
+#: django_celery_beat/models.py:198 django_celery_beat/models.py:199
+msgid "clocked"
+msgstr "programado"
+
+#: django_celery_beat/models.py:239
+msgid "Minute(s)"
+msgstr "Minuto(s)"
+
+#: django_celery_beat/models.py:240
+msgid "Cron Minutes to Run. Use \"*\" for \"all\". (Example: \"0,30\")"
+msgstr ""
+"Minutos de Cron para Ejecutar. Usa \"*\" para \"todos\". (Ejemplo: \"0,30\")"
+
+#: django_celery_beat/models.py:246
+msgid "Hour(s)"
+msgstr "Hora(s)"
+
+#: django_celery_beat/models.py:247
+msgid "Cron Hours to Run. Use \"*\" for \"all\". (Example: \"8,20\")"
+msgstr ""
+"Horas de Cron para Ejecutar. Usa \"*\" para \"todas\". (Ejemplo: \"8,20\")"
+
+#: django_celery_beat/models.py:253
+msgid "Day(s) Of The Week"
+msgstr "Día(s) de la Semana"
+
+#: django_celery_beat/models.py:255
+msgid "Cron Days Of The Week to Run. Use \"*\" for \"all\". (Example: \"0,5\")"
+msgstr ""
+"Días de la Semana de Cron para Ejecutar. Usa \"*\" para \"todos\". (Ejemplo: "
+"\"0,5\")"
+
+#: django_celery_beat/models.py:262
+msgid "Day(s) Of The Month"
+msgstr "Día(s) del Mes"
+
+#: django_celery_beat/models.py:264
+msgid ""
+"Cron Days Of The Month to Run. Use \"*\" for \"all\". (Example: \"1,15\")"
+msgstr ""
+"Días del Mes de Cron para Ejecutar. Usa \"*\" para \"todos\". (Ejemplo: "
+"\"1,15\")"
+
+#: django_celery_beat/models.py:271
+msgid "Month(s) Of The Year"
+msgstr "Mes(es) del Año"
+
+#: django_celery_beat/models.py:273
+msgid ""
+"Cron Months Of The Year to Run. Use \"*\" for \"all\". (Example: \"0,6\")"
+msgstr ""
+"Meses del Año de Cron para Ejecutar. Usa \"*\" para \"todos\". (Ejemplo: "
+"\"0,6\")"
+
+#: django_celery_beat/models.py:280
+msgid "Cron Timezone"
+msgstr "Zona Horaria de Cron"
+
+#: django_celery_beat/models.py:281
+msgid "Timezone to Run the Cron Schedule on. Default is UTC."
+msgstr "Zona horaria para ejecutar la programación Cron. Por defecto es UTC."
+
+#: django_celery_beat/models.py:287
+msgid "crontab"
+msgstr "crontab"
+
+#: django_celery_beat/models.py:288
+msgid "crontabs"
+msgstr "crontabs"
+
+#: django_celery_beat/models.py:385
+msgid "Name"
+msgstr "Nombre"
+
+#: django_celery_beat/models.py:386
+msgid "Short Description For This Task"
+msgstr "Descripción Corta para esta Tarea"
+
+#: django_celery_beat/models.py:392
+msgid ""
+"The Name of the Celery Task that Should be Run.  (Example: \"proj.tasks."
+"import_contacts\")"
+msgstr ""
+"El Nombre de la Tarea Celery que Debe Ejecutarse. (Ejemplo: \"proj.tasks."
+"import_contacts\")"
+
+#: django_celery_beat/models.py:404
+msgid "Interval Schedule"
+msgstr "Programación por Intervalos"
+
+#: django_celery_beat/models.py:406
+msgid ""
+"Interval Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Programación por Intervalos para ejecutar la tarea. Establece solo un tipo "
+"de programación, deja los otros nulos."
+
+#: django_celery_beat/models.py:415
+msgid "Crontab Schedule"
+msgstr "Programación Crontab"
+
+#: django_celery_beat/models.py:417
+msgid ""
+"Crontab Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Programación Crontab para ejecutar la tarea. Establece solo un tipo de "
+"programación, deja los otros nulos."
+
+#: django_celery_beat/models.py:426
+msgid "Solar Schedule"
+msgstr "Programación Solar"
+
+#: django_celery_beat/models.py:428
+msgid ""
+"Solar Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Programación Solar para ejecutar la tarea. Establece solo un tipo de "
+"programación, deja los otros nulos."
+
+#: django_celery_beat/models.py:437
+msgid "Clocked Schedule"
+msgstr "Programación por Hora"
+
+#: django_celery_beat/models.py:439
+msgid ""
+"Clocked Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Programación por Hora para ejecutar la tarea. Establece solo un tipo de "
+"programación, deja los otros nulos."
+
+#: django_celery_beat/models.py:447
+msgid "Positional Arguments"
+msgstr "Argumentos Posicionales"
+
+#: django_celery_beat/models.py:448
+msgid "JSON encoded positional arguments (Example: [\"arg1\", \"arg2\"])"
+msgstr ""
+"Argumentos posicionales codificados en JSON (Ejemplo: [\"arg1\", \"arg2\"])"
+
+#: django_celery_beat/models.py:453
+msgid "Keyword Arguments"
+msgstr "Argumentos con Palabra Clave"
+
+#: django_celery_beat/models.py:455
+msgid "JSON encoded keyword arguments (Example: {\"argument\": \"value\"})"
+msgstr ""
+"Argumentos con palabra clave codificados en JSON (Ejemplo: {\"argument\": "
+"\"value\"})"
+
+#: django_celery_beat/models.py:464
+msgid "Queue Override"
+msgstr "Anulación de Cola"
+
+#: django_celery_beat/models.py:466
+msgid "Queue defined in CELERY_TASK_QUEUES. Leave None for default queuing."
+msgstr "Cola definida en CELERY_TASK_QUEUES. Deja None para cola por defecto."
+
+#: django_celery_beat/models.py:478
+msgid "Exchange"
+msgstr "Exchange"
+
+#: django_celery_beat/models.py:479
+msgid "Override Exchange for low-level AMQP routing"
+msgstr "Anular Exchange para enrutamiento AMQP de bajo nivel"
+
+#: django_celery_beat/models.py:486
+msgid "Routing Key"
+msgstr "Clave de Enrutamiento"
+
+#: django_celery_beat/models.py:487
+msgid "Override Routing Key for low-level AMQP routing"
+msgstr "Anular Clave de Enrutamiento para enrutamiento AMQP de bajo nivel"
+
+#: django_celery_beat/models.py:492
+msgid "AMQP Message Headers"
+msgstr "Cabeceras de Mensaje AMQP"
+
+#: django_celery_beat/models.py:493
+msgid "JSON encoded message headers for the AMQP message."
+msgstr "Cabeceras de mensaje codificadas en JSON para el mensaje AMQP."
+
+#: django_celery_beat/models.py:501
+msgid "Priority"
+msgstr "Prioridad"
+
+#: django_celery_beat/models.py:503
+msgid ""
+"Priority Number between 0 and 255. Supported by: RabbitMQ, Redis (priority "
+"reversed, 0 is highest)."
+msgstr ""
+"Número de Prioridad entre 0 y 255. Soportado por: RabbitMQ, Redis (prioridad "
+"invertida, 0 es la más alta)."
+
+#: django_celery_beat/models.py:510
+msgid "Expires Datetime"
+msgstr "Fecha y Hora de Expiración"
+
+#: django_celery_beat/models.py:512
+msgid ""
+"Datetime after which the schedule will no longer trigger the task to run"
+msgstr ""
+"Fecha y hora después de la cual la programación ya no activará la ejecución "
+"de la tarea"
+
+#: django_celery_beat/models.py:519
+msgid "Expires timedelta with seconds"
+msgstr "Expira timedelta con segundos"
+
+#: django_celery_beat/models.py:521
+msgid ""
+"Timedelta with seconds which the schedule will no longer trigger the task to "
+"run"
+msgstr ""
+"Timedelta con segundos después del cual la programación ya no activará la "
+"ejecución de la tarea"
+
+#: django_celery_beat/models.py:527
+msgid "One-off Task"
+msgstr "Tarea Única"
+
+#: django_celery_beat/models.py:528
+msgid "If True, the schedule will only run the task a single time"
+msgstr "Si es Verdadero, la programación ejecutará la tarea solo una vez"
+
+#: django_celery_beat/models.py:533
+msgid "Start Datetime"
+msgstr "Fecha y Hora de Inicio"
+
+#: django_celery_beat/models.py:535
+msgid "Datetime when the schedule should begin triggering the task to run"
+msgstr ""
+"Fecha y hora cuando la programación debe comenzar a activar la ejecución de "
+"la tarea"
+
+#: django_celery_beat/models.py:540
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: django_celery_beat/models.py:541
+msgid "Set to False to disable the schedule"
+msgstr "Establecer en Falso para deshabilitar la programación"
+
+#: django_celery_beat/models.py:549
+msgid "Last Run Datetime"
+msgstr "Fecha y Hora de Última Ejecución"
+
+#: django_celery_beat/models.py:551
+msgid ""
+"Datetime that the schedule last triggered the task to run. Reset to None if "
+"enabled is set to False."
+msgstr ""
+"Fecha y hora en que la programación activó por última vez la ejecución de la "
+"tarea. Se restablece a None si habilitado se establece en Falso."
+
+#: django_celery_beat/models.py:558
+msgid "Total Run Count"
+msgstr "Conteo Total de Ejecuciones"
+
+#: django_celery_beat/models.py:560
+msgid "Running count of how many times the schedule has triggered the task"
+msgstr "Conteo continuo de cuántas veces la programación ha activado la tarea"
+
+#: django_celery_beat/models.py:565
+msgid "Last Modified"
+msgstr "Última Modificación"
+
+#: django_celery_beat/models.py:566
+msgid "Datetime that this PeriodicTask was last modified"
+msgstr "Fecha y hora en que esta Tarea Periódica fue modificada por última vez"
+
+#: django_celery_beat/models.py:570
+msgid "Description"
+msgstr "Descripción"
+
+#: django_celery_beat/models.py:571
+msgid "Detailed description about the details of this Periodic Task"
+msgstr "Descripción detallada sobre los detalles de esta Tarea Periódica"
+
+#: django_celery_beat/models.py:576
+msgid "This is the configuration area for executing asynchronous tasks."
+msgstr "Esta es el área de configuración de ejecución de tareas asíncronas."
+
+#: django_celery_beat/models.py:597
+msgid "Content"
+msgstr "Contenido"
+
+#: django_celery_beat/models.py:598
+msgid "Scheduler"
+msgstr "Programador"
+
+#: django_celery_beat/models.py:608
+msgid "periodic task"
+msgstr "tarea periódica"
+
+#: django_celery_beat/models.py:609
+msgid "periodic tasks"
+msgstr "tareas periódicas"
+
+#: django_celery_beat/templates/admin/djcelery/change_list.html:6
+msgid "Home"
+msgstr "Inicio"
+
+#: django_celery_beat/views.py:34
+#, python-brace-format
+msgid "Task {0} was successfully run"
+msgstr "La tarea {0} fue ejecutada exitosamente"
+
+#: django_celery_beat/wagtail_hooks.py:193
+msgid "Tasks"
+msgstr "Tareas"
+
+#: reference/models.py:34
+msgid "Marked"
+msgstr "Marcado"
+
+#: reference/models.py:35
+msgid "Marked XML"
+msgstr "XML Marcado"
+
+#: reference/wagtail_hooks.py:45
+msgid "Reference"
+msgstr "Referencia"
+
+#: tracker/choices.py:9
+msgid "error"
+msgstr "error"
+
+#: tracker/choices.py:10
+msgid "warning"
+msgstr "advertencia"
+
+#: tracker/choices.py:11
+msgid "info"
+msgstr "información"
+
+#: tracker/choices.py:12
+msgid "exception"
+msgstr "excepción"
+
+#: tracker/choices.py:24
+msgid "To reprocess"
+msgstr "Para reprocesar"
+
+#: tracker/choices.py:25
+msgid "To do"
+msgstr "Por hacer"
+
+#: tracker/choices.py:26
+msgid "Done"
+msgstr "Completado"
+
+#: tracker/choices.py:27
+msgid "Doing"
+msgstr "Haciendo"
+
+#: tracker/choices.py:28
+msgid "Pending"
+msgstr "Pendiente"
+
+#: tracker/choices.py:29
+msgid "ignored"
+msgstr "ignorado"
+
+#: tracker/choices.py:41
+msgid "XML Parsing Error"
+msgstr "Error de Análisis XML"
+
+#: tracker/choices.py:42
+msgid "XML Validation Error"
+msgstr "Error de Validación XML"
+
+#: tracker/choices.py:43
+msgid "XML Conversion to DOCX Error"
+msgstr "Error de Conversión XML a DOCX"
+
+#: tracker/choices.py:44
+msgid "XML Conversion to HTML Error"
+msgstr "Error de Conversión XML a HTML"
+
+#: tracker/choices.py:45
+msgid "XML Conversion to PDF Error"
+msgstr "Error de Conversión XML a PDF"
+
+#: tracker/choices.py:46
+msgid "XML Conversion to TEX Error"
+msgstr "Error de Conversión XML a TEX"
+
+#: tracker/choices.py:47
+msgid "Unknown Error"
+msgstr "Error Desconocido"
+
+#: tracker/models.py:28
+msgid "Error Type"
+msgstr "Tipo de Error"
+
+#: tracker/models.py:35
+msgid "Data"
+msgstr "Datos"
+
+#: tracker/models.py:39
+msgid "Message"
+msgstr "Mensaje"
+
+#: tracker/models.py:44
+msgid "Handled"
+msgstr "Manejado"
+
+#: tracker/models.py:70
+msgid "XML Document Event"
+msgstr "Evento de Documento XML"
+
+#: tracker/models.py:71 tracker/wagtail_hooks.py:16
+msgid "XML Document Events"
+msgstr "Eventos de Documento XML"
+
+#: tracker/models.py:77
+msgid "Exception Type"
+msgstr "Tipo de Excepción"
+
+#: tracker/models.py:78
+msgid "Exception Msg"
+msgstr "Mensaje de Excepción"
+
+#: tracker/models.py:82
+msgid "Item"
+msgstr "Elemento"
+
+#: tracker/models.py:88 xml_manager/wagtail_hooks.py:69
+msgid "Action"
+msgstr "Acción"
+
+#: tracker/models.py:101
+msgid "General Event"
+msgstr "Evento General"
+
+#: tracker/models.py:102 tracker/wagtail_hooks.py:47
+msgid "General Events"
+msgstr "Eventos Generales"
+
+#: tracker/wagtail_hooks.py:81
+msgid "Unexpected Events"
+msgstr "Eventos Inesperados"
+
+#: users/admin.py:13
+msgid "Personal info"
+msgstr "Información personal"
+
+#: users/admin.py:15
+msgid "Permissions"
+msgstr "Permisos"
+
+#: users/admin.py:26
+msgid "Important dates"
+msgstr "Fechas importantes"
+
+#: users/forms.py:11
+msgid "This username has already been taken."
+msgstr "Este nombre de usuario ya ha sido tomado."
+
+#: users/models.py:15
+msgid "Name of User"
+msgstr "Nombre del Usuario"
+
+#: xml_manager/models.py:9
+msgid "XML File"
+msgstr "Archivo XML"
+
+#: xml_manager/models.py:10
+msgid "Upload an XML file for processing."
+msgstr "Subir un archivo XML para procesamiento."
+
+#: xml_manager/models.py:16
+msgid "Validation File"
+msgstr "Archivo de Validación"
+
+#: xml_manager/models.py:22
+msgid "Exceptions File"
+msgstr "Archivo de Excepciones"
+
+#: xml_manager/models.py:26 xml_manager/models.py:61 xml_manager/models.py:93
+msgid "Uploaded At"
+msgstr "Subido En"
+
+#: xml_manager/models.py:27
+msgid "The date and time when the file was uploaded."
+msgstr "La fecha y hora cuando el archivo fue subido."
+
+#: xml_manager/models.py:38 xml_manager/models.py:43 xml_manager/models.py:82
+#: xml_manager/wagtail_hooks.py:56 xml_manager/wagtail_hooks.py:60
+msgid "XML Document"
+msgstr "Documento XML"
+
+#: xml_manager/models.py:39 xml_manager/wagtail_hooks.py:57
+msgid "XML Documents"
+msgstr "Documentos XML"
+
+#: xml_manager/models.py:46
+msgid "PDF File"
+msgstr "Archivo PDF"
+
+#: xml_manager/models.py:50
+msgid "DOCX File"
+msgstr "Archivo DOCX"
+
+#: xml_manager/models.py:53
+msgid "Intermediate DOCX file generated during PDF creation"
+msgstr "Archivo DOCX intermedio generado durante la creación del PDF"
+
+#: xml_manager/models.py:58 xml_manager/models.py:90
+msgid "Language"
+msgstr "Idioma"
+
+#: xml_manager/models.py:59 xml_manager/models.py:91
+msgid "Language code or name"
+msgstr "Código o nombre del idioma"
+
+#: xml_manager/models.py:67 xml_manager/wagtail_hooks.py:77
+#: xml_manager/wagtail_hooks.py:81
+msgid "XML Document PDF"
+msgstr "PDF de Documento XML"
+
+#: xml_manager/models.py:68 xml_manager/wagtail_hooks.py:78
+msgid "XML Document PDFs"
+msgstr "PDFs de Documento XML"
+
+#: xml_manager/models.py:85
+msgid "HTML File"
+msgstr "Archivo HTML"
+
+#: xml_manager/models.py:99 xml_manager/wagtail_hooks.py:98
+#: xml_manager/wagtail_hooks.py:102
+msgid "XML Document HTML"
+msgstr "HTML de Documento XML"
+
+#: xml_manager/models.py:100 xml_manager/wagtail_hooks.py:99
+msgid "XML Document HTMLs"
+msgstr "HTMLs de Documento XML"
+
+#: xml_manager/wagtail_hooks.py:66
+msgid "Validation file"
+msgstr "Archivo de validación"
+
+#: xml_manager/wagtail_hooks.py:67
+msgid "Exceptions file"
+msgstr "Archivo de excepciones"
+
+#: xml_manager/wagtail_hooks.py:118
+msgid "XML Manager"
+msgstr "Gestor XML"
+
+#~ msgid "AÃ§Ãµes"
+#~ msgstr "Acciones"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,866 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-03 12:15+0000\n"
+"PO-Revision-Date: 2025-09-03 HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Portuguese (Brazil) <pt_BR@li.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: core/home/templates/home/welcome_page.html:6
+msgid "Visit the Wagtail website"
+msgstr "Visite o site do Wagtail"
+
+#: core/home/templates/home/welcome_page.html:15
+msgid "View the release notes"
+msgstr "Ver as notas de lançamento"
+
+#: core/home/templates/home/welcome_page.html:27
+msgid "Welcome to your new Wagtail site!"
+msgstr "Bem-vindo ao seu novo site Wagtail!"
+
+#: core/home/templates/home/welcome_page.html:28
+msgid ""
+"Please feel free to <a href=\"https://github.com/wagtail/wagtail/wiki/Slack"
+"\">join our community on Slack</a>, or get started with one of the links "
+"below."
+msgstr ""
+"Sinta-se à vontade para <a href=\"https://github.com/wagtail/wagtail/wiki/"
+"Slack\">juntar-se à nossa comunidade no Slack</a>, ou comece com um dos "
+"links abaixo."
+
+#: core/home/templates/home/welcome_page.html:35
+msgid "Wagtail Documentation"
+msgstr "Documentação do Wagtail"
+
+#: core/home/templates/home/welcome_page.html:36
+msgid "Topics, references, & how-tos"
+msgstr "Tópicos, referências e guias práticos"
+
+#: core/home/templates/home/welcome_page.html:42
+msgid "Tutorial"
+msgstr "Tutorial"
+
+#: core/home/templates/home/welcome_page.html:43
+msgid "Build your first Wagtail site"
+msgstr "Construa seu primeiro site Wagtail"
+
+#: core/home/templates/home/welcome_page.html:49
+msgid "Admin Interface"
+msgstr "Interface Administrativa"
+
+#: core/home/templates/home/welcome_page.html:50
+msgid "Create your superuser first!"
+msgstr "Crie seu superusuário primeiro!"
+
+#: core/models.py:19 tracker/models.py:76
+msgid "Creation date"
+msgstr "Data de criação"
+
+#: core/models.py:22
+msgid "Last update date"
+msgstr "Data da última atualização"
+
+#: core/models.py:27
+msgid "Creator"
+msgstr "Criador"
+
+#: core/models.py:37
+msgid "Updater"
+msgstr "Atualizador"
+
+#: core_settings/models.py:18 core_settings/models.py:19
+msgid "Site configuration"
+msgstr "Configuração do site"
+
+#: core_settings/models.py:66
+msgid "Site settings"
+msgstr "Configurações do site"
+
+#: core_settings/models.py:67
+msgid "Admin settings"
+msgstr "Configurações administrativas"
+
+#: django_celery_beat/admin.py:69 django_celery_beat/forms.py:55
+msgid "Task (registered)"
+msgstr "Tarefa (registrada)"
+
+#: django_celery_beat/admin.py:73 django_celery_beat/forms.py:59
+msgid "Task (custom)"
+msgstr "Tarefa (personalizada)"
+
+#: django_celery_beat/admin.py:90 django_celery_beat/forms.py:75
+msgid "Need name of task"
+msgstr "É necessário o nome da tarefa"
+
+#: django_celery_beat/admin.py:96 django_celery_beat/forms.py:81
+#: django_celery_beat/models.py:648
+msgid "Only one can be set, in expires and expire_seconds"
+msgstr "Apenas um pode ser definido, entre expires e expire_seconds"
+
+#: django_celery_beat/admin.py:106 django_celery_beat/forms.py:91
+#, python-format
+msgid "Unable to parse JSON: %s"
+msgstr "Não foi possível analisar JSON: %s"
+
+#: django_celery_beat/admin.py:207 django_celery_beat/wagtail_hooks.py:70
+#, python-brace-format
+msgid "{0} task{1} {2} successfully {3}"
+msgstr "{0} tarefa{1} {2} com sucesso {3}"
+
+#: django_celery_beat/admin.py:210 django_celery_beat/admin.py:283
+#: django_celery_beat/wagtail_hooks.py:73
+#: django_celery_beat/wagtail_hooks.py:154
+msgid "was,were"
+msgstr "foi,foram"
+
+#: django_celery_beat/admin.py:220 django_celery_beat/wagtail_hooks.py:83
+msgid "Enable selected tasks"
+msgstr "Habilitar tarefas selecionadas"
+
+#: django_celery_beat/admin.py:227 django_celery_beat/wagtail_hooks.py:90
+msgid "Disable selected tasks"
+msgstr "Desabilitar tarefas selecionadas"
+
+#: django_celery_beat/admin.py:242 django_celery_beat/wagtail_hooks.py:105
+msgid "Toggle activity of selected tasks"
+msgstr "Alternar atividade das tarefas selecionadas"
+
+#: django_celery_beat/admin.py:266 django_celery_beat/wagtail_hooks.py:130
+#, python-brace-format
+msgid "task \"{0}\" not found"
+msgstr "tarefa \"{0}\" não encontrada"
+
+#: django_celery_beat/admin.py:280 django_celery_beat/wagtail_hooks.py:151
+#, python-brace-format
+msgid "{0} task{1} {2} successfully run"
+msgstr "{0} tarefa{1} {2} executada{1} com sucesso"
+
+#: django_celery_beat/admin.py:287 django_celery_beat/wagtail_hooks.py:158
+msgid "Run selected tasks"
+msgstr "Executar tarefas selecionadas"
+
+#: django_celery_beat/apps.py:13
+msgid "Periodic Tasks"
+msgstr "Tarefas Periódicas"
+
+#: django_celery_beat/button_helper.py:15
+msgid "Run"
+msgstr "Executar"
+
+#: django_celery_beat/choices.py:10
+msgid "Days"
+msgstr "Dias"
+
+#: django_celery_beat/choices.py:11
+msgid "Hours"
+msgstr "Horas"
+
+#: django_celery_beat/choices.py:12
+msgid "Minutes"
+msgstr "Minutos"
+
+#: django_celery_beat/choices.py:13
+msgid "Seconds"
+msgstr "Segundos"
+
+#: django_celery_beat/choices.py:14
+msgid "Microseconds"
+msgstr "Microssegundos"
+
+#: django_celery_beat/choices.py:18
+msgid "Day"
+msgstr "Dia"
+
+#: django_celery_beat/choices.py:19
+msgid "Hour"
+msgstr "Hora"
+
+#: django_celery_beat/choices.py:20
+msgid "Minute"
+msgstr "Minuto"
+
+#: django_celery_beat/choices.py:21
+msgid "Second"
+msgstr "Segundo"
+
+#: django_celery_beat/choices.py:22
+msgid "Microsecond"
+msgstr "Microssegundo"
+
+#: django_celery_beat/choices.py:26
+msgid "Astronomical dawn"
+msgstr "Aurora astronômica"
+
+#: django_celery_beat/choices.py:27
+msgid "Civil dawn"
+msgstr "Aurora civil"
+
+#: django_celery_beat/choices.py:28
+msgid "Nautical dawn"
+msgstr "Aurora náutica"
+
+#: django_celery_beat/choices.py:29
+msgid "Astronomical dusk"
+msgstr "Crepúsculo astronômico"
+
+#: django_celery_beat/choices.py:30
+msgid "Civil dusk"
+msgstr "Crepúsculo civil"
+
+#: django_celery_beat/choices.py:31
+msgid "Nautical dusk"
+msgstr "Crepúsculo náutico"
+
+#: django_celery_beat/choices.py:32
+msgid "Solar noon"
+msgstr "Meio-dia solar"
+
+#: django_celery_beat/choices.py:33
+msgid "Sunrise"
+msgstr "Nascer do sol"
+
+#: django_celery_beat/choices.py:34
+msgid "Sunset"
+msgstr "Pôr do sol"
+
+#: django_celery_beat/models.py:70
+msgid "Solar Event"
+msgstr "Evento Solar"
+
+#: django_celery_beat/models.py:71
+msgid "The type of solar event when the job should run"
+msgstr "O tipo de evento solar quando a tarefa deve ser executada"
+
+#: django_celery_beat/models.py:76
+msgid "Latitude"
+msgstr "Latitude"
+
+#: django_celery_beat/models.py:77
+msgid "Run the task when the event happens at this latitude"
+msgstr "Executar a tarefa quando o evento acontecer nesta latitude"
+
+#: django_celery_beat/models.py:83
+msgid "Longitude"
+msgstr "Longitude"
+
+#: django_celery_beat/models.py:84
+msgid "Run the task when the event happens at this longitude"
+msgstr "Executar a tarefa quando o evento acontecer nesta longitude"
+
+#: django_celery_beat/models.py:91
+msgid "solar event"
+msgstr "evento solar"
+
+#: django_celery_beat/models.py:92
+msgid "solar events"
+msgstr "eventos solares"
+
+#: django_celery_beat/models.py:132
+msgid "Number of Periods"
+msgstr "Número de Períodos"
+
+#: django_celery_beat/models.py:134
+msgid "Number of interval periods to wait before running the task again"
+msgstr ""
+"Número de períodos de intervalo a aguardar antes de executar a tarefa "
+"novamente"
+
+#: django_celery_beat/models.py:141
+msgid "Interval Period"
+msgstr "Período do Intervalo"
+
+#: django_celery_beat/models.py:142
+msgid "The type of period between task runs (Example: days)"
+msgstr "O tipo de período entre execuções da tarefa (Exemplo: dias)"
+
+#: django_celery_beat/models.py:148
+msgid "interval"
+msgstr "intervalo"
+
+#: django_celery_beat/models.py:149
+msgid "intervals"
+msgstr "intervalos"
+
+#: django_celery_beat/models.py:175
+msgid "every {}"
+msgstr "a cada {}"
+
+#: django_celery_beat/models.py:180
+msgid "every {} {}"
+msgstr "a cada {} {}"
+
+#: django_celery_beat/models.py:191
+msgid "Clock Time"
+msgstr "Horário do Relógio"
+
+#: django_celery_beat/models.py:192
+msgid "Run the task at clocked time"
+msgstr "Executar a tarefa no horário programado"
+
+#: django_celery_beat/models.py:198 django_celery_beat/models.py:199
+msgid "clocked"
+msgstr "programado"
+
+#: django_celery_beat/models.py:239
+msgid "Minute(s)"
+msgstr "Minuto(s)"
+
+#: django_celery_beat/models.py:240
+msgid "Cron Minutes to Run. Use \"*\" for \"all\". (Example: \"0,30\")"
+msgstr ""
+"Minutos do Cron para Executar. Use \"*\" para \"todos\". (Exemplo: \"0,30\")"
+
+#: django_celery_beat/models.py:246
+msgid "Hour(s)"
+msgstr "Hora(s)"
+
+#: django_celery_beat/models.py:247
+msgid "Cron Hours to Run. Use \"*\" for \"all\". (Example: \"8,20\")"
+msgstr ""
+"Horas do Cron para Executar. Use \"*\" para \"todas\". (Exemplo: \"8,20\")"
+
+#: django_celery_beat/models.py:253
+msgid "Day(s) Of The Week"
+msgstr "Dia(s) da Semana"
+
+#: django_celery_beat/models.py:255
+msgid "Cron Days Of The Week to Run. Use \"*\" for \"all\". (Example: \"0,5\")"
+msgstr ""
+"Dias da Semana do Cron para Executar. Use \"*\" para \"todos\". (Exemplo: "
+"\"0,5\")"
+
+#: django_celery_beat/models.py:262
+msgid "Day(s) Of The Month"
+msgstr "Dia(s) do Mês"
+
+#: django_celery_beat/models.py:264
+msgid ""
+"Cron Days Of The Month to Run. Use \"*\" for \"all\". (Example: \"1,15\")"
+msgstr ""
+"Dias do Mês do Cron para Executar. Use \"*\" para \"todos\". (Exemplo: "
+"\"1,15\")"
+
+#: django_celery_beat/models.py:271
+msgid "Month(s) Of The Year"
+msgstr "Mês(es) do Ano"
+
+#: django_celery_beat/models.py:273
+msgid ""
+"Cron Months Of The Year to Run. Use \"*\" for \"all\". (Example: \"0,6\")"
+msgstr ""
+"Meses do Ano do Cron para Executar. Use \"*\" para \"todos\". (Exemplo: "
+"\"0,6\")"
+
+#: django_celery_beat/models.py:280
+msgid "Cron Timezone"
+msgstr "Fuso Horário do Cron"
+
+#: django_celery_beat/models.py:281
+msgid "Timezone to Run the Cron Schedule on. Default is UTC."
+msgstr "Fuso horário para executar o agendamento Cron. Padrão é UTC."
+
+#: django_celery_beat/models.py:287
+msgid "crontab"
+msgstr "crontab"
+
+#: django_celery_beat/models.py:288
+msgid "crontabs"
+msgstr "crontabs"
+
+#: django_celery_beat/models.py:385
+msgid "Name"
+msgstr "Nome"
+
+#: django_celery_beat/models.py:386
+msgid "Short Description For This Task"
+msgstr "Descrição Curta para Esta Tarefa"
+
+#: django_celery_beat/models.py:392
+msgid ""
+"The Name of the Celery Task that Should be Run.  (Example: \"proj.tasks."
+"import_contacts\")"
+msgstr ""
+"O Nome da Tarefa Celery que Deve ser Executada. (Exemplo: \"proj.tasks."
+"import_contacts\")"
+
+#: django_celery_beat/models.py:404
+msgid "Interval Schedule"
+msgstr "Agendamento por Intervalo"
+
+#: django_celery_beat/models.py:406
+msgid ""
+"Interval Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Agendamento por Intervalo para executar a tarefa. Defina apenas um tipo de "
+"agendamento, deixe os outros nulos."
+
+#: django_celery_beat/models.py:415
+msgid "Crontab Schedule"
+msgstr "Agendamento Crontab"
+
+#: django_celery_beat/models.py:417
+msgid ""
+"Crontab Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Agendamento Crontab para executar a tarefa. Defina apenas um tipo de "
+"agendamento, deixe os outros nulos."
+
+#: django_celery_beat/models.py:426
+msgid "Solar Schedule"
+msgstr "Agendamento Solar"
+
+#: django_celery_beat/models.py:428
+msgid ""
+"Solar Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Agendamento Solar para executar a tarefa. Defina apenas um tipo de "
+"agendamento, deixe os outros nulos."
+
+#: django_celery_beat/models.py:437
+msgid "Clocked Schedule"
+msgstr "Agendamento por Horário"
+
+#: django_celery_beat/models.py:439
+msgid ""
+"Clocked Schedule to run the task on.  Set only one schedule type, leave the "
+"others null."
+msgstr ""
+"Agendamento por Horário para executar a tarefa. Defina apenas um tipo de "
+"agendamento, deixe os outros nulos."
+
+#: django_celery_beat/models.py:447
+msgid "Positional Arguments"
+msgstr "Argumentos Posicionais"
+
+#: django_celery_beat/models.py:448
+msgid "JSON encoded positional arguments (Example: [\"arg1\", \"arg2\"])"
+msgstr ""
+"Argumentos posicionais codificados em JSON (Exemplo: [\"arg1\", \"arg2\"])"
+
+#: django_celery_beat/models.py:453
+msgid "Keyword Arguments"
+msgstr "Argumentos Nomeados"
+
+#: django_celery_beat/models.py:455
+msgid "JSON encoded keyword arguments (Example: {\"argument\": \"value\"})"
+msgstr ""
+"Argumentos nomeados codificados em JSON (Exemplo: {\"argument\": \"value\"})"
+
+#: django_celery_beat/models.py:464
+msgid "Queue Override"
+msgstr "Substituição de Fila"
+
+#: django_celery_beat/models.py:466
+msgid "Queue defined in CELERY_TASK_QUEUES. Leave None for default queuing."
+msgstr "Fila definida em CELERY_TASK_QUEUES. Deixe None para fila padrão."
+
+#: django_celery_beat/models.py:478
+msgid "Exchange"
+msgstr "Exchange"
+
+#: django_celery_beat/models.py:479
+msgid "Override Exchange for low-level AMQP routing"
+msgstr "Substituir Exchange para roteamento AMQP de baixo nível"
+
+#: django_celery_beat/models.py:486
+msgid "Routing Key"
+msgstr "Chave de Roteamento"
+
+#: django_celery_beat/models.py:487
+msgid "Override Routing Key for low-level AMQP routing"
+msgstr "Substituir Chave de Roteamento para roteamento AMQP de baixo nível"
+
+#: django_celery_beat/models.py:492
+msgid "AMQP Message Headers"
+msgstr "Cabeçalhos de Mensagem AMQP"
+
+#: django_celery_beat/models.py:493
+msgid "JSON encoded message headers for the AMQP message."
+msgstr "Cabeçalhos de mensagem codificados em JSON para a mensagem AMQP."
+
+#: django_celery_beat/models.py:501
+msgid "Priority"
+msgstr "Prioridade"
+
+#: django_celery_beat/models.py:503
+msgid ""
+"Priority Number between 0 and 255. Supported by: RabbitMQ, Redis (priority "
+"reversed, 0 is highest)."
+msgstr ""
+"Número de Prioridade entre 0 e 255. Suportado por: RabbitMQ, Redis "
+"(prioridade invertida, 0 é a mais alta)."
+
+#: django_celery_beat/models.py:510
+msgid "Expires Datetime"
+msgstr "Data e Hora de Expiração"
+
+#: django_celery_beat/models.py:512
+msgid ""
+"Datetime after which the schedule will no longer trigger the task to run"
+msgstr ""
+"Data e hora após a qual o agendamento não irá mais disparar a execução da "
+"tarefa"
+
+#: django_celery_beat/models.py:519
+msgid "Expires timedelta with seconds"
+msgstr "Expira timedelta com segundos"
+
+#: django_celery_beat/models.py:521
+msgid ""
+"Timedelta with seconds which the schedule will no longer trigger the task to "
+"run"
+msgstr ""
+"Timedelta com segundos após o qual o agendamento não irá mais disparar a "
+"execução da tarefa"
+
+#: django_celery_beat/models.py:527
+msgid "One-off Task"
+msgstr "Tarefa Única"
+
+#: django_celery_beat/models.py:528
+msgid "If True, the schedule will only run the task a single time"
+msgstr "Se Verdadeiro, o agendamento executará a tarefa apenas uma vez"
+
+#: django_celery_beat/models.py:533
+msgid "Start Datetime"
+msgstr "Data e Hora de Início"
+
+#: django_celery_beat/models.py:535
+msgid "Datetime when the schedule should begin triggering the task to run"
+msgstr ""
+"Data e hora quando o agendamento deve começar a disparar a execução da tarefa"
+
+#: django_celery_beat/models.py:540
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: django_celery_beat/models.py:541
+msgid "Set to False to disable the schedule"
+msgstr "Definir como Falso para desabilitar o agendamento"
+
+#: django_celery_beat/models.py:549
+msgid "Last Run Datetime"
+msgstr "Data e Hora da Última Execução"
+
+#: django_celery_beat/models.py:551
+msgid ""
+"Datetime that the schedule last triggered the task to run. Reset to None if "
+"enabled is set to False."
+msgstr ""
+"Data e hora em que o agendamento disparou pela última vez a execução da "
+"tarefa. Resetado para None se habilitado for definido como Falso."
+
+#: django_celery_beat/models.py:558
+msgid "Total Run Count"
+msgstr "Contagem Total de Execuções"
+
+#: django_celery_beat/models.py:560
+msgid "Running count of how many times the schedule has triggered the task"
+msgstr "Contagem contínua de quantas vezes o agendamento disparou a tarefa"
+
+#: django_celery_beat/models.py:565
+msgid "Last Modified"
+msgstr "Última Modificação"
+
+#: django_celery_beat/models.py:566
+msgid "Datetime that this PeriodicTask was last modified"
+msgstr ""
+"Data e hora em que esta Tarefa Periódica foi modificada pela última vez"
+
+#: django_celery_beat/models.py:570
+msgid "Description"
+msgstr "Descrição"
+
+#: django_celery_beat/models.py:571
+msgid "Detailed description about the details of this Periodic Task"
+msgstr "Descrição detalhada sobre os detalhes desta Tarefa Periódica"
+
+#: django_celery_beat/models.py:576
+msgid "This is the configuration area for executing asynchronous tasks."
+msgstr "Esta é a área de configuração de execução de tarefas assíncronas."
+
+#: django_celery_beat/models.py:597
+msgid "Content"
+msgstr "Conteúdo"
+
+#: django_celery_beat/models.py:598
+msgid "Scheduler"
+msgstr "Agendador"
+
+#: django_celery_beat/models.py:608
+msgid "periodic task"
+msgstr "tarefa periódica"
+
+#: django_celery_beat/models.py:609
+msgid "periodic tasks"
+msgstr "tarefas periódicas"
+
+#: django_celery_beat/templates/admin/djcelery/change_list.html:6
+msgid "Home"
+msgstr "Início"
+
+#: django_celery_beat/views.py:34
+#, python-brace-format
+msgid "Task {0} was successfully run"
+msgstr "Tarefa {0} foi executada com sucesso"
+
+#: django_celery_beat/wagtail_hooks.py:193
+msgid "Tasks"
+msgstr "Tarefas"
+
+#: reference/models.py:34
+msgid "Marked"
+msgstr "Marcado"
+
+#: reference/models.py:35
+msgid "Marked XML"
+msgstr "XML Marcado"
+
+#: reference/wagtail_hooks.py:45
+msgid "Reference"
+msgstr "Referência"
+
+#: tracker/choices.py:9
+msgid "error"
+msgstr "erro"
+
+#: tracker/choices.py:10
+msgid "warning"
+msgstr "aviso"
+
+#: tracker/choices.py:11
+msgid "info"
+msgstr "informação"
+
+#: tracker/choices.py:12
+msgid "exception"
+msgstr "exceção"
+
+#: tracker/choices.py:24
+msgid "To reprocess"
+msgstr "Para reprocessar"
+
+#: tracker/choices.py:25
+msgid "To do"
+msgstr "Para fazer"
+
+#: tracker/choices.py:26
+msgid "Done"
+msgstr "Concluído"
+
+#: tracker/choices.py:27
+msgid "Doing"
+msgstr "Fazendo"
+
+#: tracker/choices.py:28
+msgid "Pending"
+msgstr "Pendente"
+
+#: tracker/choices.py:29
+msgid "ignored"
+msgstr "ignorado"
+
+#: tracker/choices.py:41
+msgid "XML Parsing Error"
+msgstr "Erro de Análise XML"
+
+#: tracker/choices.py:42
+msgid "XML Validation Error"
+msgstr "Erro de Validação XML"
+
+#: tracker/choices.py:43
+msgid "XML Conversion to DOCX Error"
+msgstr "Erro de Conversão XML para DOCX"
+
+#: tracker/choices.py:44
+msgid "XML Conversion to HTML Error"
+msgstr "Erro de Conversão XML para HTML"
+
+#: tracker/choices.py:45
+msgid "XML Conversion to PDF Error"
+msgstr "Erro de Conversão XML para PDF"
+
+#: tracker/choices.py:46
+msgid "XML Conversion to TEX Error"
+msgstr "Erro de Conversão XML para TEX"
+
+#: tracker/choices.py:47
+msgid "Unknown Error"
+msgstr "Erro Desconhecido"
+
+#: tracker/models.py:28
+msgid "Error Type"
+msgstr "Tipo de Erro"
+
+#: tracker/models.py:35
+msgid "Data"
+msgstr "Dados"
+
+#: tracker/models.py:39
+msgid "Message"
+msgstr "Mensagem"
+
+#: tracker/models.py:44
+msgid "Handled"
+msgstr "Tratado"
+
+#: tracker/models.py:70
+msgid "XML Document Event"
+msgstr "Evento de Documento XML"
+
+#: tracker/models.py:71 tracker/wagtail_hooks.py:16
+msgid "XML Document Events"
+msgstr "Eventos de Documento XML"
+
+#: tracker/models.py:77
+msgid "Exception Type"
+msgstr "Tipo de Exceção"
+
+#: tracker/models.py:78
+msgid "Exception Msg"
+msgstr "Mensagem de Exceção"
+
+#: tracker/models.py:82
+msgid "Item"
+msgstr "Item"
+
+#: tracker/models.py:88 xml_manager/wagtail_hooks.py:69
+msgid "Action"
+msgstr "Ação"
+
+#: tracker/models.py:101
+msgid "General Event"
+msgstr "Evento Geral"
+
+#: tracker/models.py:102 tracker/wagtail_hooks.py:47
+msgid "General Events"
+msgstr "Eventos Gerais"
+
+#: tracker/wagtail_hooks.py:81
+msgid "Unexpected Events"
+msgstr "Eventos Inesperados"
+
+#: users/admin.py:13
+msgid "Personal info"
+msgstr "Informações pessoais"
+
+#: users/admin.py:15
+msgid "Permissions"
+msgstr "Permissões"
+
+#: users/admin.py:26
+msgid "Important dates"
+msgstr "Datas importantes"
+
+#: users/forms.py:11
+msgid "This username has already been taken."
+msgstr "Este nome de usuário já foi utilizado."
+
+#: users/models.py:15
+msgid "Name of User"
+msgstr "Nome do Usuário"
+
+#: xml_manager/models.py:9
+msgid "XML File"
+msgstr "Arquivo XML"
+
+#: xml_manager/models.py:10
+msgid "Upload an XML file for processing."
+msgstr "Enviar um arquivo XML para processamento."
+
+#: xml_manager/models.py:16
+msgid "Validation File"
+msgstr "Arquivo de Validação"
+
+#: xml_manager/models.py:22
+msgid "Exceptions File"
+msgstr "Arquivo de Exceções"
+
+#: xml_manager/models.py:26 xml_manager/models.py:61 xml_manager/models.py:93
+msgid "Uploaded At"
+msgstr "Enviado Em"
+
+#: xml_manager/models.py:27
+msgid "The date and time when the file was uploaded."
+msgstr "A data e hora quando o arquivo foi enviado."
+
+#: xml_manager/models.py:38 xml_manager/models.py:43 xml_manager/models.py:82
+#: xml_manager/wagtail_hooks.py:56 xml_manager/wagtail_hooks.py:60
+msgid "XML Document"
+msgstr "Documento XML"
+
+#: xml_manager/models.py:39 xml_manager/wagtail_hooks.py:57
+msgid "XML Documents"
+msgstr "Documentos XML"
+
+#: xml_manager/models.py:46
+msgid "PDF File"
+msgstr "Arquivo PDF"
+
+#: xml_manager/models.py:50
+msgid "DOCX File"
+msgstr "Arquivo DOCX"
+
+#: xml_manager/models.py:53
+msgid "Intermediate DOCX file generated during PDF creation"
+msgstr "Arquivo DOCX intermediário gerado durante a criação do PDF"
+
+#: xml_manager/models.py:58 xml_manager/models.py:90
+msgid "Language"
+msgstr "Idioma"
+
+#: xml_manager/models.py:59 xml_manager/models.py:91
+msgid "Language code or name"
+msgstr "Código ou nome do idioma"
+
+#: xml_manager/models.py:67 xml_manager/wagtail_hooks.py:77
+#: xml_manager/wagtail_hooks.py:81
+msgid "XML Document PDF"
+msgstr "PDF de Documento XML"
+
+#: xml_manager/models.py:68 xml_manager/wagtail_hooks.py:78
+msgid "XML Document PDFs"
+msgstr "PDFs de Documento XML"
+
+#: xml_manager/models.py:85
+msgid "HTML File"
+msgstr "Arquivo HTML"
+
+#: xml_manager/models.py:99 xml_manager/wagtail_hooks.py:98
+#: xml_manager/wagtail_hooks.py:102
+msgid "XML Document HTML"
+msgstr "HTML de Documento XML"
+
+#: xml_manager/models.py:100 xml_manager/wagtail_hooks.py:99
+msgid "XML Document HTMLs"
+msgstr "HTMLs de Documento XML"
+
+#: xml_manager/wagtail_hooks.py:66
+msgid "Validation file"
+msgstr "Arquivo de validação"
+
+#: xml_manager/wagtail_hooks.py:67
+msgid "Exceptions file"
+msgstr "Arquivo de exceções"
+
+#: xml_manager/wagtail_hooks.py:118
+msgid "XML Manager"
+msgstr "Gerenciador XML"
+
+#~ msgid "Ações"
+#~ msgstr "Ações"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-03 12:15+0000\n"
+"POT-Creation-Date: 2025-09-04 14:18+0000\n"
 "PO-Revision-Date: 2025-09-03 HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Brazil) <pt_BR@li.org>\n"
@@ -623,13 +623,33 @@ msgstr "Tarefa {0} foi executada com sucesso"
 msgid "Tasks"
 msgstr "Tarefas"
 
-#: reference/models.py:34
+#: reference/models.py:15
+msgid "Mixed Citation"
+msgstr "Citação Mista"
+
+#: reference/models.py:30
+#, fuzzy
+#| msgid "Reference"
+msgid "Referência"
+msgstr "Referência"
+
+#: reference/models.py:31
+#, fuzzy
+#| msgid "Reference"
+msgid "Referências"
+msgstr "Referência"
+
+#: reference/models.py:38
 msgid "Marked"
 msgstr "Marcado"
 
-#: reference/models.py:35
+#: reference/models.py:39
 msgid "Marked XML"
 msgstr "XML Marcado"
+
+#: reference/models.py:48
+msgid "Rating from 1 to 10"
+msgstr "Classificação de 1 a 10"
 
 #: reference/wagtail_hooks.py:45
 msgid "Reference"
@@ -861,6 +881,19 @@ msgstr "Arquivo de exceções"
 #: xml_manager/wagtail_hooks.py:118
 msgid "XML Manager"
 msgstr "Gerenciador XML"
+
+#, fuzzy
+#~| msgid "Marked"
+#~ msgid "marked"
+#~ msgstr "Marcado"
+
+#, fuzzy
+#~| msgid "Marked"
+#~ msgid "marked_xml"
+#~ msgstr "Marcado"
+
+#~ msgid "score"
+#~ msgstr "pontuação"
 
 #~ msgid "Ações"
 #~ msgstr "Ações"

--- a/reference/models.py
+++ b/reference/models.py
@@ -6,13 +6,13 @@ from wagtail.models import Orderable
 from wagtail.admin.panels import FieldPanel, InlinePanel
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.core.validators import MinValueValidator, MaxValueValidator
 from core.forms import CoreAdminModelForm
 
 # Create your models here
 class Reference(CommonControlField, ClusterableModel):
-    mixed_citation = models.TextField(("Mixed Citation"), null=False, blank=True)
+    mixed_citation = models.TextField(_("Mixed Citation"), null=False, blank=True)
 
     estatus = models.IntegerField(default=0) 
 
@@ -25,6 +25,10 @@ class Reference(CommonControlField, ClusterableModel):
 
     def __str__(self):
         return self.mixed_citation
+
+    class Meta:
+        verbose_name = _("Referência")
+        verbose_name_plural = _("Referências")
 
 
 class ElementCitation(Orderable):
@@ -41,7 +45,7 @@ class ElementCitation(Orderable):
             MinValueValidator(1),  # Mínimo 1
             MaxValueValidator(10)  # Máximo 10
         ],
-        help_text="Rating from 1 to 10"
+        help_text=_("Rating from 1 to 10")
     )
 
     panels = [

--- a/reference/wagtail_hooks.py
+++ b/reference/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponseRedirect
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail_modeladmin.options import (
     ModelAdmin,
     ModelAdminGroup,

--- a/tracker/models.py
+++ b/tracker/models.py
@@ -98,8 +98,8 @@ class GeneralEvent(models.Model):
             models.Index(fields=["action"]),
         ]
         ordering = ["-created"]
-    verbose_name = _("General Event")
-    verbose_name_plural = _("General Events")
+        verbose_name = _("General Event")
+        verbose_name_plural = _("General Events")
 
     def __str__(self):
         if self.item or self.action:

--- a/tracker/wagtail_hooks.py
+++ b/tracker/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail_modeladmin.options import (
     ModelAdmin,
     ModelAdminGroup,

--- a/xml_manager/tasks.py
+++ b/xml_manager/tasks.py
@@ -3,7 +3,7 @@ import os
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from config import celery_app
 from tracker.choices import (

--- a/xml_manager/wagtail_hooks.py
+++ b/xml_manager/wagtail_hooks.py
@@ -66,7 +66,7 @@ class XMLDocumentSnippetViewSet(SnippetViewSet):
         LinkColumn("validation_file", label=_("Validation file")),
         LinkColumn("exceptions_file", label=_("Exceptions file")),
         "uploaded_at",
-        ActionColumn("actions", label=_("Ações")),
+        ActionColumn("actions", label=_("Action")),
     )
 
     search_fields = ("xml_file",)


### PR DESCRIPTION
#### O que esse PR faz?
Implementa suporte completo de internacionalização (i18n) para a aplicação Django, adicionando traduções em português brasileiro (pt-BR), inglês (en) e espanhol (es). O PR soluciona a ausência de localização para usuários não falantes de inglês, incluindo tradução de todos os textos do Django Celery Beat (agendamento de tarefas), módulos core da aplicação, sistema de tracking, gerenciador XML e interface administrativa.

#### Onde a revisão poderia começar?
A revisão deve iniciar pelos arquivos de configuração de idioma:

- `locale/pt_BR/LC_MESSAGES/django.po` (tradução principal em português)
- `locale/es/LC_MESSAGES/django.po` (tradução em espanhol)
- `locale/en/LC_MESSAGES/django.po` (baseline em inglês)

Em seguida, verificar as configurações em `settings.py` relacionadas a` LANGUAGES`, `LOCALE_PATHS` e `USE_I18N`.

#### Como este poderia ser testado manualmente?

1. Executar `python manage.py compilemessages` para gerar os arquivos `.mo`
2. Configurar `LANGUAGE_CODE = 'pt-br'` no `settings.py` e reiniciar o servidor
3. Acessar a interface administrativa do Django Celery Beat
4. Verificar se textos como "Tarefas Periódicas", "Agendamento por Intervalos", etc. aparecem em português
5. Testar alternância entre idiomas se implementado seletor de idioma
6. Validar pluralização com contadores (ex: "1 tarefa" vs "2 tarefas")
7. Repetir testes para espanhol (es) e inglês (en)

#### Algum cenário de contexto que queira dar?
A aplicação possui forte dependência do Django Celery Beat para agendamento de tarefas assíncronas, incluindo funcionalidades avançadas como agendamento solar (baseado em eventos astronômicos) e configuração de cron jobs. Com usuários em diferentes países da América Latina, a localização se torna essencial para adoção e usabilidade. As traduções mantêm precisão técnica em termos astronômicos (aurora astronômica, crepúsculo náutico) e preservam terminologia técnica internacional (AMQP, JSON, crontab).

Implementação de Internacionalização com URLs Multilíngues: Configura suporte a múltiplos idiomas (pt-br, es, en) usando i18n_patterns no Django/Wagtail. As URLs agora suportam prefixos de idioma (/pt-br/admin/, /es/admin/, /en/admin/) enquanto APIs permanecem sem prefixo. Inclui configuração do `LocaleMiddleware`, estrutura de diretórios `locale/`, e comandos para gerar/compilar traduções. Testado via URLs diretas e alternância por cookie.

### Screenshots
N.A.

#### Quais são tickets relevantes?
TK #21 

### Referências
[Django Internationalization Documentation](https://docs.djangoproject.com/en/stable/topics/i18n/)
[GNU gettext Manual](https://www.gnu.org/software/gettext/manual/gettext.html)
[Django Celery Beat Documentation](https://django-celery-beat.readthedocs.io/)
[Wagtail Internationalization Guide](https://docs.wagtail.org/en/stable/advanced_topics/i18n/)
