### PR TITLE
Infraestrutura de testes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       #  uses: pre-commit/action@v3.0.0
 
   # With no caching at all the entire ci process takes 4m 30s to complete!
-  pytest:
+  tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -54,7 +54,10 @@ jobs:
         run:  docker compose -f local.yml run --rm django python manage.py migrate
 
       - name: Run Django Tests
-        run:  docker compose -f local.yml run django pytest || true
+        run:  docker compose -f local.yml run --rm django python manage.py test --settings=config.settings.test
+
+      - name: Run Pytest
+        run:  docker compose -f local.yml run --rm django pytest
 
       - name: Tear down the Stack
         run:  docker compose -f local.yml down

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,19 @@ django_bash: ## Open a bash terminar from django container using $(compose)
 	@docker compose -f $(compose) run --rm django bash
 
 django_test: ## Run tests from django container using $(compose)
-	@docker compose -f $(compose) run --rm django python manage.py test
+	@docker compose -f $(compose) run --rm django python manage.py test --settings=config.settings.test
 
 django_fast: ## Run tests fast from django container using $(compose)
-	@docker compose -f $(compose) run --rm django python manage.py test --failfast
+	@docker compose -f $(compose) run --rm django python manage.py test --settings=config.settings.test --failfast
+
+pytest: ## Run pytest from django container using $(compose)
+	@docker compose -f $(compose) run --rm django pytest
+
+pytest_fast: ## Run pytest stopping on first failure using $(compose)
+	@docker compose -f $(compose) run --rm django pytest -x
+
+pytest_cov: ## Run pytest with coverage report using $(compose)
+	@docker compose -f $(compose) run --rm django pytest --cov --cov-report=term-missing
 
 django_makemigrations: ## Run makemigrations from django container using $(compose)
 	@docker compose -f $(compose) run --rm django python manage.py makemigrations

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,4 +8,8 @@ watchgod==0.8.2  # https://github.com/samuelcolvin/watchgod
 django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 django-debug-toolbar  # https://github.com/jazzband/django-debug-toolbar
 
-pytest >= 7.0.7
+pytest==8.3.5
+pytest-django==4.11.1
+pytest-cov==6.1.1
+coverage==7.8.0
+django-coverage-plugin==3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,16 @@ django_settings_module = config.settings.test
 ignore_errors = True
 
 [coverage:run]
-include = core/*
-omit = *migrations*, *tests*
+include =
+    users/*
+    core/*
+    core_settings/*
+    markup_doc/*
+    markuplib/*
+    xml_manager/*
+    reference/*
+    tracker/*
+    model_ai/*
+omit = *migrations*, *tests*, */tests/*
 plugins =
     django_coverage_plugin

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,8 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 
-# Create your tests here.
+from users.models import CustomUser
+
+
+class SmokeTestCase(SimpleTestCase):
+    def test_custom_user_model_is_configured(self):
+        self.assertEqual(CustomUser._meta.label, "users.CustomUser")


### PR DESCRIPTION

#### O que esse PR faz?

Corrige e unifica a infraestrutura de testes do markapi, que estava incompleta (sem `config.settings.test`, dependências de pytest incompletas, CI a ignorar falhas com `|| true`).

**Entregas principais:**

- **`config/settings/test.py`** — settings partilhadas por `manage.py test` e `pytest` (PostgreSQL via Compose, Celery eager, cache em memória, sem debug toolbar, `LLAMA_ENABLED=False`).
- **`pytest.ini`** + dependências em `requirements/local.txt` (`pytest-django`, `pytest-cov`, `coverage`, `django-coverage-plugin`).
- **Smoke test** em `users/tests.py` (valida que `CustomUser` está configurado).
- **CI** — job renomeado para `tests`; remove `|| true`; executa `manage.py test` e `pytest` com `--rm`.
- **Makefile** — `django_test`/`django_fast` usam `--settings=config.settings.test`; novos alvos `pytest`, `pytest_fast`, `pytest_cov`.
- **`setup.cfg`** — paths de cobertura alinhados às apps do projeto.
- **Documentação** — `docs/testing.md` e secção Testing do `README.md`.

Este PR **não** adiciona testes de negócio das apps editoriais; o objetivo é pipeline reproduzível (Docker + CI) que falha de verdade em regressões de configuração.

#### Onde a revisão poderia começar?

1. `config/settings/test.py`
2. `pytest.ini` e `requirements/local.txt`
3. `.github/workflows/ci.yml`
4. `Makefile` (alvos de teste)
5. `users/tests.py`

#### Como este poderia ser testado manualmente?

1. Na raiz do repositório: `make build` (obrigatório após mudança em `requirements/local.txt`).
2. `make up` (ou `docker compose -f local.yml up -d postgres redis`).
3. `make django_migrate`
4. `make django_test` — esperado: `Ran 1 test` / `OK`.
5. `make pytest` — esperado: `1 passed`.
6. `make pytest_cov` — relatório de cobertura no terminal.
7. (Opcional) Simular CI:

   ```bash
   docker compose -f local.yml build
   docker compose -f local.yml run --rm django python manage.py migrate
   docker compose -f local.yml run --rm django python manage.py test --settings=config.settings.test
   docker compose -f local.yml run --rm django pytest
   docker compose -f local.yml down
   ```

Guia completo: [`docs/testing.md`](../testing.md).

#### Algum cenário de contexto que queira dar?

- O projeto herdava referências cookiecutter-django (`config.settings.test` no mypy, README com `pytest`/`coverage`) sem ficheiros nem deps correspondentes.
- O Makefile já usava `manage.py test`, mas a CI corria só `pytest` com `|| true`, logo o pipeline nunca falhava.
- Mantém-se **PostgreSQL** nos testes (não SQLite), por causa de `django.contrib.postgres` e do stack Wagtail.
- Hoje a suite tem **1 smoke test**; stubs vazios continuam em `markup_doc`, `xml_manager` e `reference` para testes futuros.

#### Screenshots

N/A

#### Quais são tickets relevantes?

N/A

#### Referências

- [`docs/testing.md`](../testing.md)
- Plano interno: infraestrutura de testes (2026-05-15)

---
