### PR TITLE
Atualiza dependências Python (gunicorn, sentry, pytest)

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,8 +8,8 @@ watchgod==0.8.2  # https://github.com/samuelcolvin/watchgod
 django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 django-debug-toolbar  # https://github.com/jazzband/django-debug-toolbar
 
-pytest==8.3.5
+pytest==9.0.3
 pytest-django==4.11.1
-pytest-cov==6.1.1
-coverage==7.8.0
+pytest-cov==7.1.0
+coverage==7.10.6
 django-coverage-plugin==3.1.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,9 +3,9 @@
 -r base.txt
 
 gevent==24.2.1  # http://www.gevent.org/
-gunicorn==21.2.0 # https://github.com/benoitc/gunicorn
+gunicorn==26.0.0
 psycopg2-binary==2.9.9  # https://github.com/psycopg/psycopg2
-sentry-sdk[django]==2.5.1  # https://github.com/getsentry/sentry-python
+sentry-sdk[django]==2.60.0
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

#### O que esse PR faz?

Aplica bumps de dependências Python sugeridos pelo Dependabot em [pulls](https://github.com/scieloorg/markapi/pulls), **sem** Traefik, Postgres Docker nem GitHub Actions.

| Pacote | Antes | Depois | Ficheiro |
|--------|-------|--------|----------|
| gunicorn | 21.2.0 | 26.0.0 | `requirements/production.txt` |
| sentry-sdk[django] | 2.5.1 | 2.60.0 | `requirements/production.txt` |
| pytest | 8.3.5 | 9.0.3 | `requirements/local.txt` |
| pytest-cov | 6.1.1 | 7.1.0 | `requirements/local.txt` |
| coverage | 7.8.0 | 7.10.6 | `requirements/local.txt` (exigido por pytest-cov 7.1) |

**Não alterado (de propósito):**

- `setuptools>=82` (PR #84) — mantido `setuptools>=68.2.2,<82` por `packtools` / `pkg_resources`
- Traefik, Postgres 18, `actions/checkout`, `actions/setup-python`

#### Onde a revisão poderia começar?

- `requirements/local.txt`
- `requirements/production.txt`

#### Como este poderia ser testado manualmente?

1. `make build`
2. `make up -d`
3. Confirmar logs do django: servidor em http://127.0.0.1:8009
4. `make django_test` e `make pytest` — 1 teste OK
5. (Produção) rebuild imagem production e smoke com gunicorn quando fizer deploy

#### Algum cenário de contexto que queira dar?

Validado localmente com `docker compose -f local.yml build`, `up -d django`, testes e HTTP 200 em `/admin/login/`. Bumps de produção (gunicorn, sentry) entram na imagem `local` apenas via wheels partilhados se rebuild completo; deploy production deve rebuildar com `production.txt`.

#### Screenshots

N/A

#### Quais são tickets relevantes?

Dependabot: #87, #86, #89, #85 (parcial). Fechar #84 com comentário se setuptools 82 for adiado.

#### Referências

- https://github.com/scieloorg/markapi/pulls
