### PR TITLE
Atualiza dependências Dependabot (Python, Docker, Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
 
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           #cache: pip
@@ -45,7 +45,7 @@ jobs:
     steps:
 
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Build the Stack
         run:  docker compose -f local.yml build

--- a/compose/production/postgres/Dockerfile
+++ b/compose/production/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15.3
+FROM postgres:18.4
 
 COPY ./compose/production/postgres/maintenance /usr/local/bin/maintenance
 RUN chmod +x /usr/local/bin/maintenance/*

--- a/compose/production/traefik/Dockerfile
+++ b/compose/production/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:2.10.3
+FROM traefik:v3.7.1
 RUN mkdir -p /etc/traefik/acme \
   && touch /etc/traefik/acme/acme.json \
   && chmod 600 /etc/traefik/acme/acme.json

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 setuptools>=68.2.2,<82
-whitenoise==6.6.0  # https://github.com/evansd/whitenoise
-redis==5.0.1  # https://github.com/redis/redis-py
+whitenoise==6.12.0  # https://github.com/evansd/whitenoise
+redis==7.4.0  # https://github.com/redis/redis-py
 celery==5.3.6  # pyup: < 6.0  # https://github.com/celery/celery
 flower==2.0.1  # https://github.com/mher/flower
 hiredis==2.2.3  # https://github.com/redis/hiredis-py
@@ -27,7 +27,7 @@ lxml==4.9.4 # https://github.com/lxml/lxml
 
 # Kombu
 # ------------------------------------------------------------------------------
-kombu==5.4.2
+kombu==5.6.2
 
 # Tenacity
 # ------------------------------------------------------------------------------

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,7 +2,7 @@
 
 -r base.txt
 
-gevent==24.2.1  # http://www.gevent.org/
+gevent==26.4.0  # http://www.gevent.org/
 gunicorn==26.0.0
 psycopg2-binary==2.9.9  # https://github.com/psycopg/psycopg2
 sentry-sdk[django]==2.60.0

--- a/scripts/postgres_pre_upgrade_backup.sh
+++ b/scripts/postgres_pre_upgrade_backup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-${ROOT_DIR}/local.yml}"
+COMPOSE_SERVICE="${COMPOSE_SERVICE:-postgres}"
+ARCHIVE_ROOT="${ARCHIVE_ROOT:-${ROOT_DIR}/../scms_data/markapi/postgres_backups_pre_upgrade}"
+TIMESTAMP="$(date +'%Y_%m_%dT%H_%M_%S')"
+ARCHIVE_DIR="${ARCHIVE_ROOT}/${TIMESTAMP}"
+
+cd "${ROOT_DIR}"
+
+if ! docker compose -f "${COMPOSE_FILE}" ps --status running "${COMPOSE_SERVICE}" 2>/dev/null | grep -q "${COMPOSE_SERVICE}"; then
+    echo "Serviço ${COMPOSE_SERVICE} não está em execução. Suba o stack: docker compose -f ${COMPOSE_FILE} up -d ${COMPOSE_SERVICE}"
+    exit 1
+fi
+
+echo "A criar backup lógico (pg_dump) no contentor ${COMPOSE_SERVICE}..."
+docker compose -f "${COMPOSE_FILE}" exec -T "${COMPOSE_SERVICE}" backup
+
+mkdir -p "${ARCHIVE_DIR}"
+BACKUP_VOLUME="${BACKUP_VOLUME:-../scms_data/markapi/data_dev_backup}"
+
+if [[ -d "${ROOT_DIR}/${BACKUP_VOLUME}" ]]; then
+    shopt -s nullglob
+    backups=("${ROOT_DIR}/${BACKUP_VOLUME}"/backup_*.sql.gz)
+    shopt -u nullglob
+    if [[ ${#backups[@]} -eq 0 ]]; then
+        echo "Nenhum ficheiro backup_*.sql.gz em ${ROOT_DIR}/${BACKUP_VOLUME}"
+        exit 1
+    fi
+    latest_backup="$(ls -t "${backups[@]}" | head -1)"
+    cp -a "${latest_backup}" "${ARCHIVE_DIR}/"
+    cp -a "${latest_backup}" "${ARCHIVE_ROOT}/latest_pre_upgrade.sql.gz"
+    echo "Cópia de segurança: ${ARCHIVE_DIR}/$(basename "${latest_backup}")"
+    echo "Atalho: ${ARCHIVE_ROOT}/latest_pre_upgrade.sql.gz"
+else
+    echo "Volume de backups não encontrado (${ROOT_DIR}/${BACKUP_VOLUME}). O dump foi criado no contentor em /backups."
+fi
+
+echo "Concluído. Antes de subir Postgres 18, pare django/celery e siga docs/ops/postgres-upgrade-backup.md"


### PR DESCRIPTION

## Corpo do PR

#### O que esse PR faz?

Consolida os PRs abertos com label `dependencies` em [scieloorg/markapi/pulls](https://github.com/scieloorg/markapi/pulls):

**Backup Postgres:** `scripts/postgres_pre_upgrade_backup.sh` e `docs/ops/postgres-upgrade-backup.md`. Backup de exemplo criado em `../scms_data/markapi/postgres_backups_pre_upgrade/` (não versionado).

**Kubernetes HML:** StatefulSet continua em `postgres:15.3` até migração planificada no cluster.

#### Onde a revisão poderia começar?

- `requirements/base.txt`, `requirements/production.txt`
- `docs/ops/postgres-upgrade-backup.md`, `scripts/postgres_pre_upgrade_backup.sh`
- `compose/production/postgres/Dockerfile`, `compose/production/traefik/Dockerfile`
- `.github/workflows/ci.yml`

#### Como este poderia ser testado manualmente?

1. `./scripts/postgres_pre_upgrade_backup.sh` com stack local a correr.
2. `docker compose -f local.yml build django && docker compose -f local.yml run --rm django pytest`
3. Upgrade Postgres 18: seguir passos numerados em `docs/ops/postgres-upgrade-backup.md` (não substituir volume PG15 sem backup).
4. Produção Traefik: rebuild da imagem e validar TLS/rotas após deploy.

#### Algum cenário de contexto que queira dar?

- `setuptools>=82` (PR #84) falha na importação de `packtools` (`ModuleNotFoundError: pkg_resources`). Manter `<82` até packtools migrar.
- A mudança do Dockerfile para `postgres:18.4` não migra automaticamente volumes existentes; o backup lógico é obrigatório.
- Traefik v3 mantém configuração estática próxima da v2; validar ACME e routers em ambiente real.

#### Screenshots

N/A

#### Quais são tickets relevantes?

N/A #81, #82, #84, #88, #94–#98

#### Referências
N/A